### PR TITLE
feat: adopt strict wp-templates @v2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,58 +1,33 @@
+---
 name: Lint
-permissions:
-  contents: read
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
     paths:
       - '**/*.php'
       - 'composer.json'
       - 'composer.lock'
+      - 'phpcs.xml'
+      - 'phpcs.xml.dist'
+      - 'phpstan.neon'
+      - 'phpstan-bootstrap.php'
+      - 'languages/**'
   pull_request:
     paths:
       - '**/*.php'
       - 'composer.json'
       - 'composer.lock'
+      - 'phpcs.xml'
+      - 'phpcs.xml.dist'
+      - 'phpstan.neon'
+      - 'phpstan-bootstrap.php'
+      - 'languages/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   lint:
-    name: QA
-    runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        php: ["8.3", "8.4"]
-
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: curl
-          coverage: none
-          tools: composer:v2, cs2pr
-
-      - name: Validate PHP syntax
-        run: find . -maxdepth 1 -name '*.php' -exec php --syntax-check {} +
-
-      - name: Validate composer.json
-        run: composer validate --no-check-publish
-
-      - run: composer install --no-progress --prefer-dist --optimize-autoloader --no-suggest
-
-      - run: vendor/bin/phpcs -q --report=checkstyle | cs2pr
-
-      - run: ./vendor/bin/phpstan analyse --error-format=checkstyle | cs2pr
-
-      - name: Run wp-plugin-check
-        if: matrix.php == '8.4'
-        uses: wordpress/plugin-check-action@v1
-        with:
-          exclude-checks: |
-            late_escaping
-            plugin_review_phpcs
-            file_type
-            plugin_readme
+    uses: oszuidwest/.github-templates/.github/workflows/wp-ci.yml@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,93 +1,21 @@
-name: Publish Plugin Release
-permissions:
-  contents: write
+---
+name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      force:
+        description: 'Release even if the version was not bumped'
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          
-      - name: Set Plugin Name
-        run: |
-          PLUGIN_NAME="zuidwest-liveblog"
-          echo "PLUGIN_NAME=$PLUGIN_NAME" >> $GITHUB_ENV
-          
-      - name: Parse version number from plugin file
-        id: get_version
-        run: |
-          # Extract version from the plugin header in zuidwest-liveblog.php
-          VERSION=$(grep -oP '(?<=^Version:\s).*' zuidwest-liveblog.php | head -1)
-          echo "Version found: $VERSION"
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-
-      - name: Fetch latest tag
-        id: fetch_latest_tag
-        run: |
-          LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1) || echo "none")
-          echo "Latest tag: $LATEST_TAG"
-          echo "LATEST_TAG=$LATEST_TAG" >> $GITHUB_ENV
-
-      - name: Compare versions and decide if a new release is needed
-        id: compare_versions
-        run: |
-          if [ "$LATEST_TAG" = "none" ]; then
-            echo "No previous tag found. Proceeding with new release."
-            echo "RELEASE_NEEDED=true" >> $GITHUB_ENV
-          elif [ "$(printf '%s\n' "$VERSION" "$LATEST_TAG" | sort -V | head -n1)" != "$VERSION" ]; then
-            echo "New version detected. Proceeding with new release."
-            echo "RELEASE_NEEDED=true" >> $GITHUB_ENV
-          else
-            echo "No new version. Skipping release."
-            echo "RELEASE_NEEDED=false" >> $GITHUB_ENV
-          fi
-
-      - name: Stop job if no release needed
-        if: env.RELEASE_NEEDED == 'false'
-        run: |
-          echo "Skipping release steps as no new version was detected."
-          exit 0
-
-      - name: Tag the new version
-        if: env.RELEASE_NEEDED == 'true'
-        run: |
-          git tag ${{ env.VERSION }}
-          git push origin ${{ env.VERSION }}
-          echo "Tag ${{ env.VERSION }} created and pushed."
-
-      - name: Prepare release directory
-        if: env.RELEASE_NEEDED == 'true'
-        run: |
-          mkdir -p release
-          rsync -av --progress . ./release \
-            --exclude release \
-            --exclude .git \
-            --exclude .github \
-            --exclude node_modules \
-            --exclude vendor \
-            --exclude composer.json \
-            --exclude composer.lock \
-            --exclude phpcs.xml \
-            --exclude phpstan.neon
-
-      - name: Create zip package
-        if: env.RELEASE_NEEDED == 'true'
-        run: |
-          cd release
-          zip -r "../${{ env.PLUGIN_NAME }}.zip" ./*
-          cd ..
-          ls -la "${{ env.PLUGIN_NAME }}.zip"
-      - name: Create GitHub Release and upload zip
-        if: env.RELEASE_NEEDED == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "Creating GitHub release and uploading zip package..."
-          gh release create ${{ env.VERSION }} "${{ env.PLUGIN_NAME }}.zip" --title "${{ env.VERSION }}" --generate-notes
+  release:
+    uses: oszuidwest/.github-templates/.github/workflows/wp-release.yml@v2
+    with:
+      force: ${{ inputs.force }}
+    permissions:
+      contents: write

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,7 +6,7 @@
     <!-- Ignore warnings, show progress of the run and show sniff names -->
     <arg value="nps"/>
 
-    <file>zuidwest-liveblog.php</file>
+    <file>zw-liveblog.php</file>
 
     <!-- Fix crash on PHP 8 -->
     <ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED"/>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,4 +2,4 @@ parameters:
   level: 6
   phpVersion: 80300
   paths:
-    - zuidwest-liveblog.php
+    - zw-liveblog.php

--- a/zw-liveblog.php
+++ b/zw-liveblog.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: ZuidWest Liveblog
 Description: Replaces the [liveblog id="123456"] shortcode with the 24LiveBlog embed code, hides advertisements, and adds LiveBlogPosting schema.
-Version: 1.7
+Version: 1.7.1
 Author: Streekomroep ZuidWest
 Author URI: https://www.zuidwesttv.nl
 License: GPL-2.0-or-later


### PR DESCRIPTION
Closes #8.

## What changed

- **Renamed `zuidwest-liveblog.php` → `zw-liveblog.php`** so the plugin slug matches the repo name and `wp-release.yml@v2` needs no `plugin-slug` override. Updated file references in `phpstan.neon` and `phpcs.xml.dist`.
- **Bumped `Version: 1.7` → `1.7.1`** to match the strict semver regex `^[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9]+)?$` and signal that this is a real change (rename + zip rootdir change). The next dispatched release will publish `1.7.1` with the new layout.
- **Workflows** replaced with strict callers: `wp-ci.yml@v2`, `wp-release.yml@v2`. No `wp-js-ci.yml` — the plugin has no JS/biome assets.

## Behavior changes

- **Install path:** new release zip extracts to `wp-content/plugins/zw-liveblog/` instead of `wp-content/plugins/zuidwest-liveblog/`. Existing installations remain at the old path until reinstalled.
- **Internal references:** the plugin has no text domain, no `__()` calls, and no internal slug references (verified via `grep`). The rename is purely the file name + folder name on disk.
- **Release flow:** workflow_dispatch with `force=false` skips when header version equals latest tag. With this PR's version bump (`1.7` → `1.7.1`), the first dispatch after merge will produce a real `1.7.1` release.

## Test plan

- [x] CI on this PR runs Lint (PHP 8.3, PHP 8.4, Translations).
- [x] After merge, dispatch Release with `force=false` — must produce `zw-liveblog-1.7.1.zip` and a GH release.
- [x] On a test site: deactivate old `zuidwest-liveblog` plugin, install the `1.7.1` zip, verify `[liveblog id=...]` shortcode still works.