### PR TITLE
Align PHPCS baseline

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,34 +1,50 @@
 <?xml version="1.0"?>
-<ruleset>
+<ruleset name="oszuidwest WordPress plugin baseline">
+    <description>
+        Baseline coding standards for oszuidwest WordPress plugins.
+        Consumer phpcs.xml adds &lt;file/&gt;, &lt;config name="text_domain"/&gt;,
+        and a PrefixAllGlobals rule with the plugin's prefixes.
+    </description>
+
+    <!-- Scan only PHP files. Consumer overrides /file/ entries. -->
     <arg name="extensions" value="php"/>
     <arg name="colors"/>
-
-    <!-- Ignore warnings, show progress of the run and show sniff names -->
-    <arg value="nps"/>
+    <arg value="sp"/>
 
     <file>zw-liveblog.php</file>
+    <file>uninstall.php</file>
 
-    <!-- Fix crash on PHP 8 -->
-    <ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED"/>
+    <!-- Stop PHP 8 from emitting deprecation warnings inside phpcs itself. -->
+    <ini name="error_reporting" value="E_ALL &amp; ~E_DEPRECATED"/>
 
-    <!-- Minimum PHP and WordPress versions -->
-    <config name="testVersion" value="8.3-"/>
-    <config name="minimum_wp_version" value="6.4"/>
+    <!-- Versions enforced across all oszuidwest plugins. -->
+    <config name="testVersion" value="8.3-8.4"/>
+    <config name="minimum_wp_version" value="6.8"/>
+    <config name="text_domain" value="zw-liveblog"/>
 
-    <rule ref="Generic.Files.EndFileNewline"/>
-
-    <rule ref="PSR12">
-        <exclude name="PSR1.Files.SideEffects.FoundWithSymbols"/>
-        <exclude name="PSR12.Files.FileHeader.SpacingAfterBlock"/>
-        <exclude name="Generic.Files.LineLength.TooLong"/>
-        <exclude name="PSR1.Methods.CamelCapsMethodName.NotCamelCaps"/>
+    <!--
+        WordPress-Extra is WordPress-Core plus best-practice sniffs.
+        WordPress-Docs adds docblock requirements.
+        PHPCompatibilityWP enforces the testVersion above.
+    -->
+    <rule ref="WordPress-Extra">
+        <!-- We use short array syntax. -->
+        <exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
+    </rule>
+    <rule ref="WordPress-Docs">
+        <!-- PHPStan type aliases aren't real PHP types. -->
+        <exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint"/>
     </rule>
     <rule ref="PHPCompatibilityWP"/>
-    <rule ref="Squiz.Strings.DoubleQuoteUsage">
 
+    <!-- Generous line limit; warning only. -->
+    <rule ref="Generic.Files.LineLength">
+        <properties>
+            <property name="lineLimit" value="160"/>
+            <property name="absoluteLineLimit" value="0"/>
+        </properties>
     </rule>
 
-    <!-- WordPress -->
     <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
         <properties>
             <property name="prefixes" type="array">
@@ -37,19 +53,8 @@
             </property>
         </properties>
     </rule>
-    <rule ref="Generic.CodeAnalysis.EmptyPHPStatement"/>
-    <rule ref="WordPress.CodeAnalysis.EscapedNotTranslated"/>
-    <rule ref="WordPress.DB"/>
-    <rule ref="WordPress.DateTime"/>
-    <rule ref="WordPress.Security">
-        <exclude name="WordPress.Security.EscapeOutput.OutputNotEscaped"/>
-    </rule>
-    <rule ref="WordPress.Utils.I18nTextDomainFixer"/>
-    <rule ref="WordPress.PHP">
-        <exclude name="WordPress.PHP.YodaConditions"/>
-        <exclude name="Universal.Operators.DisallowShortTernary"/>
-    </rule>
-    <rule ref="WordPress.WP">
-        <exclude name="WordPress.DateTime.RestrictedFunctions"/>
-    </rule>
+
+    <!-- Excluded from every consumer. -->
+    <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>node_modules/*</exclude-pattern>
 </ruleset>

--- a/uninstall.php
+++ b/uninstall.php
@@ -3,17 +3,19 @@
  * Uninstall handler for ZuidWest Liveblog plugin.
  *
  * Removes all plugin transients from the database when the plugin is deleted.
+ *
+ * @package ZuidWestLiveblog
  */
 
-if (!defined('WP_UNINSTALL_PLUGIN')) {
-    exit;
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
 }
 
 global $wpdb;
 $wpdb->query(
-    $wpdb->prepare(
-        'DELETE FROM ' . $wpdb->options . ' WHERE option_name LIKE %s OR option_name LIKE %s',
-        '_transient_zw_liveblog_%',
-        '_transient_timeout_zw_liveblog_%'
-    )
+	$wpdb->prepare(
+		'DELETE FROM ' . $wpdb->options . ' WHERE option_name LIKE %s OR option_name LIKE %s',
+		'_transient_zw_liveblog_%',
+		'_transient_timeout_zw_liveblog_%'
+	)
 );

--- a/zw-liveblog.php
+++ b/zw-liveblog.php
@@ -1,269 +1,283 @@
 <?php
-/*
-Plugin Name: ZuidWest Liveblog
-Description: Replaces the [liveblog id="123456"] shortcode with the 24LiveBlog embed code, hides advertisements, and adds LiveBlogPosting schema.
-Version: 1.7.1
-Author: Streekomroep ZuidWest
-Author URI: https://www.zuidwesttv.nl
-License: GPL-2.0-or-later
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
-Requires at least: 6.8
-Requires PHP: 8.3
-*/
+/**
+ * Plugin Name: ZuidWest Liveblog
+ * Description: Replaces the [liveblog id="123456"] shortcode with the 24LiveBlog embed code, hides advertisements, and adds LiveBlogPosting schema.
+ * Version: 1.7.1
+ * Author: Streekomroep ZuidWest
+ * Author URI: https://www.zuidwesttv.nl
+ * License: GPL-2.0-or-later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
+ * Requires at least: 6.8
+ * Requires PHP: 8.3
+ * Text Domain: zw-liveblog
+ *
+ * @package ZuidWestLiveblog
+ */
 
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
-define('ZW_LIVEBLOG_VERSION', get_file_data(__FILE__, ['Version' => 'Version'])['Version']);
+define( 'ZW_LIVEBLOG_VERSION', get_file_data( __FILE__, [ 'Version' => 'Version' ] )['Version'] );
 
-register_activation_hook(__FILE__, function (): void {
-    // Placeholder for future activation tasks
-});
+register_activation_hook(
+	__FILE__,
+	function (): void {
+		// Placeholder for future activation tasks.
+	}
+);
 
-register_deactivation_hook(__FILE__, function (): void {
-    global $wpdb;
-    $wpdb->query(
-        $wpdb->prepare(
-            'DELETE FROM ' . $wpdb->options . ' WHERE option_name LIKE %s OR option_name LIKE %s',
-            '_transient_zw_liveblog_%',
-            '_transient_timeout_zw_liveblog_%'
-        )
-    );
-});
+register_deactivation_hook(
+	__FILE__,
+	function (): void {
+		global $wpdb;
+		$wpdb->query(
+			$wpdb->prepare(
+				'DELETE FROM ' . $wpdb->options . ' WHERE option_name LIKE %s OR option_name LIKE %s',
+				'_transient_zw_liveblog_%',
+				'_transient_timeout_zw_liveblog_%'
+			)
+		);
+	}
+);
 
 /**
  * Shortcode handler.
  *
- * @param array<string, string|int>|string $atts
+ * @param array<string, string|int>|string $atts Shortcode attributes.
+ * @return string Shortcode output.
  */
-function zw_liveblog_shortcode(array|string $atts): string
-{
-    $atts = shortcode_atts(['id' => ''], $atts, 'liveblog');
-    $liveblog_id = sanitize_text_field($atts['id']);
-    if ($liveblog_id === '') {
-        return '';
-    }
-    return '<div id="LB24_LIVE_CONTENT" data-eid="' . esc_attr($liveblog_id) . '"></div>';
+function zw_liveblog_shortcode( array|string $atts ): string {
+	$atts        = shortcode_atts( [ 'id' => '' ], $atts, 'liveblog' );
+	$liveblog_id = sanitize_text_field( $atts['id'] );
+	if ( '' === $liveblog_id ) {
+		return '';
+	}
+	return '<div id="LB24_LIVE_CONTENT" data-eid="' . esc_attr( $liveblog_id ) . '"></div>';
 }
-add_shortcode('liveblog', zw_liveblog_shortcode(...));
+add_shortcode( 'liveblog', zw_liveblog_shortcode( ... ) );
 
 /**
  * Enqueue 24LiveBlog assets only when shortcode is used.
  */
-function zw_liveblog_enqueue_assets(): void
-{
-    $post = get_post();
-    if (is_singular() && $post && has_shortcode($post->post_content, 'liveblog')) {
-        // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.NoExplicitVersion -- External script, version not controlled by us
-        wp_enqueue_script('liveblog-24-js', 'https://v.24liveblog.com/24.js', [], false, [
-            'in_footer' => true,
-            'strategy' => 'defer'
-        ]);
-        wp_register_style('zw-liveblog-style', false, [], ZW_LIVEBLOG_VERSION);
-        wp_enqueue_style('zw-liveblog-style');
-        $css = '
+function zw_liveblog_enqueue_assets(): void {
+	$post = get_post();
+	if ( is_singular() && $post && has_shortcode( $post->post_content, 'liveblog' ) ) {
+		wp_enqueue_script(
+			'liveblog-24-js',
+			'https://v.24liveblog.com/24.js',
+			[],
+			ZW_LIVEBLOG_VERSION,
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			]
+		);
+		wp_register_style( 'zw-liveblog-style', false, [], ZW_LIVEBLOG_VERSION );
+		wp_enqueue_style( 'zw-liveblog-style' );
+		$css = '
             .lb24-news-list-item.lb24-base-list-ad { display: none !important; }
             #LB24 .lb24-theme-dark .lb24-base-news-container:hover {
                 background: #0000002b !important;
             }
         ';
-        wp_add_inline_style('zw-liveblog-style', $css);
-    }
+		wp_add_inline_style( 'zw-liveblog-style', $css );
+	}
 }
-add_action('wp_enqueue_scripts', zw_liveblog_enqueue_assets(...));
+add_action( 'wp_enqueue_scripts', zw_liveblog_enqueue_assets( ... ) );
 
 /**
  * Fetch the latest 100 updates (cached for 60s).
  *
+ * @param string $event_id The 24LiveBlog event ID.
  * @return array<int, array<string, mixed>>
  */
-function zw_liveblog_fetch_updates(string $event_id): array
-{
-    $transient_key = 'zw_liveblog_updates_' . md5($event_id);
-    $cached = get_transient($transient_key);
-    if (is_array($cached)) {
-        return $cached;
-    }
+function zw_liveblog_fetch_updates( string $event_id ): array {
+	$transient_key = 'zw_liveblog_updates_' . md5( $event_id );
+	$cached        = get_transient( $transient_key );
+	if ( is_array( $cached ) ) {
+		return $cached;
+	}
 
-    $url = 'https://data.24liveplus.com/v1/retrieve_server/x/event/' . $event_id . '/news/?inverted_order=1&last_nid=&limit=100';
-    $response = wp_remote_get($url, ['timeout' => 5]);
-    if (is_wp_error($response)) {
-        return [];
-    }
+	$url      = 'https://data.24liveplus.com/v1/retrieve_server/x/event/' . $event_id . '/news/?inverted_order=1&last_nid=&limit=100';
+	$response = wp_remote_get( $url, [ 'timeout' => 5 ] );
+	if ( is_wp_error( $response ) ) {
+		return [];
+	}
 
-    $body = wp_remote_retrieve_body($response);
-    if (!json_validate($body)) {
-        return [];
-    }
-    $data = json_decode($body, true);
-    $news = $data['data']['news'] ?? [];
+	$body = wp_remote_retrieve_body( $response );
+	if ( ! json_validate( $body ) ) {
+		return [];
+	}
+	$data = json_decode( $body, true );
+	$news = $data['data']['news'] ?? [];
 
-    set_transient($transient_key, $news, 60);
-    return $news;
+	set_transient( $transient_key, $news, 60 );
+	return $news;
 }
 
 /**
  * Fetch metadata (e.g., closed status, last_updated).
  *
+ * @param string $event_id The 24LiveBlog event ID.
  * @return array<string, mixed>|null
  */
-function zw_liveblog_fetch_event_meta(string $event_id): ?array
-{
-    $transient_key = 'zw_liveblog_meta_' . md5($event_id);
-    $cached = get_transient($transient_key);
-    if (is_array($cached)) {
-        return $cached;
-    }
+function zw_liveblog_fetch_event_meta( string $event_id ): ?array {
+	$transient_key = 'zw_liveblog_meta_' . md5( $event_id );
+	$cached        = get_transient( $transient_key );
+	if ( is_array( $cached ) ) {
+		return $cached;
+	}
 
-    $url = 'https://data.24liveplus.com/v1/retrieve_server/x/event/' . $event_id . '/';
-    $response = wp_remote_get($url, ['timeout' => 5]);
-    if (is_wp_error($response)) {
-        return null;
-    }
+	$url      = 'https://data.24liveplus.com/v1/retrieve_server/x/event/' . $event_id . '/';
+	$response = wp_remote_get( $url, [ 'timeout' => 5 ] );
+	if ( is_wp_error( $response ) ) {
+		return null;
+	}
 
-    $body = wp_remote_retrieve_body($response);
-    if (!json_validate($body)) {
-        return null;
-    }
-    $data = json_decode($body, true);
-    $meta = $data['data']['event'] ?? null;
+	$body = wp_remote_retrieve_body( $response );
+	if ( ! json_validate( $body ) ) {
+		return null;
+	}
+	$data = json_decode( $body, true );
+	$meta = $data['data']['event'] ?? null;
 
-    set_transient($transient_key, $meta, 60);
-    return $meta;
+	set_transient( $transient_key, $meta, 60 );
+	return $meta;
 }
 
 /**
  * Convert timestamp to local timezone in ISO 8601.
+ *
+ * @param mixed $timestamp Unix timestamp.
+ * @return string Formatted timestamp, or empty string when unavailable.
  */
-function zw_liveblog_format_wp_datetime(mixed $timestamp): string
-{
-    if (empty($timestamp) || !is_numeric($timestamp) || $timestamp <= 0) {
-        return '';
-    }
-    try {
-        $dt = (new DateTimeImmutable('@' . $timestamp))
-            ->setTimezone(wp_timezone());
-        return $dt->format(DATE_W3C);
-    } catch (Exception $e) {
-        return '';
-    }
+function zw_liveblog_format_wp_datetime( mixed $timestamp ): string {
+	if ( empty( $timestamp ) || ! is_numeric( $timestamp ) || $timestamp <= 0 ) {
+		return '';
+	}
+	try {
+		$dt = ( new DateTimeImmutable( '@' . $timestamp ) )
+			->setTimezone( wp_timezone() );
+		return $dt->format( DATE_W3C );
+	} catch ( Exception $e ) {
+		return '';
+	}
 }
 
 /**
  * Extract all liveblog IDs from content.
  *
+ * @param string $content Post content.
  * @return array<int, string>
  */
-function zw_liveblog_extract_liveblog_ids(string $content): array
-{
-    preg_match_all('/\[liveblog\s+id=["\']?(\d+)["\']?\]/i', $content, $matches);
-    return array_unique($matches[1]);
+function zw_liveblog_extract_liveblog_ids( string $content ): array {
+	preg_match_all( '/\[liveblog\s+id=["\']?(\d+)["\']?\]/i', $content, $matches );
+	return array_unique( $matches[1] );
 }
 
 /**
  * Outputs LiveBlogPosting schema with up to 100 updates per liveblog.
  */
-function zw_liveblog_add_schema_to_head(): void
-{
-    if (!is_singular()) {
-        return;
-    }
+function zw_liveblog_add_schema_to_head(): void {
+	if ( ! is_singular() ) {
+		return;
+	}
 
-    $post = get_post();
-    if (!$post) {
-        return;
-    }
-    $ids = zw_liveblog_extract_liveblog_ids($post->post_content);
-    if ($ids === []) {
-        return;
-    }
+	$post = get_post();
+	if ( ! $post ) {
+		return;
+	}
+	$ids = zw_liveblog_extract_liveblog_ids( $post->post_content );
+	if ( [] === $ids ) {
+		return;
+	}
 
-    $author_name = get_the_author_meta('display_name', (int) $post->post_author);
-    $logo_id = get_theme_mod('custom_logo');
-    $logo_url = $logo_id ? wp_get_attachment_image_url($logo_id, 'full') : '';
-    // Get coverage start time - use post time if published, otherwise current time
-    $coverage_start = get_post_time('U', true, $post);
-    if ($coverage_start === false || $coverage_start === '') {
-        // For drafts/previews, try to get start_time from first liveblog event
-        // Otherwise use current time
-        $coverage_start = time();
-        foreach ($ids as $id) {
-            $meta = zw_liveblog_fetch_event_meta($id);
-            if ($meta !== null && isset($meta['start_time']) && $meta['start_time'] > 0) {
-                $coverage_start = $meta['start_time'];
-                break;
-            }
-        }
-    }
-    $coverage_start_iso = zw_liveblog_format_wp_datetime($coverage_start);
-    $modified_time = get_post_modified_time('U', true, $post);
-    $modified_iso = zw_liveblog_format_wp_datetime($modified_time ?: time());
+	$author_name = get_the_author_meta( 'display_name', (int) $post->post_author );
+	$logo_id     = get_theme_mod( 'custom_logo' );
+	$logo_url    = $logo_id ? wp_get_attachment_image_url( $logo_id, 'full' ) : '';
+	// Get coverage start time - use post time if published, otherwise current time.
+	$coverage_start = get_post_time( 'U', true, $post );
+	if ( false === $coverage_start || '' === $coverage_start ) {
+		// For drafts/previews, try to get start_time from first liveblog event.
+		// Otherwise use current time.
+		$coverage_start = time();
+		foreach ( $ids as $id ) {
+			$meta = zw_liveblog_fetch_event_meta( $id );
+			if ( null !== $meta && isset( $meta['start_time'] ) && 0 < $meta['start_time'] ) {
+				$coverage_start = $meta['start_time'];
+				break;
+			}
+		}
+	}
+	$coverage_start_iso = zw_liveblog_format_wp_datetime( $coverage_start );
+	$modified_time      = get_post_modified_time( 'U', true, $post );
+	$modified_iso       = zw_liveblog_format_wp_datetime( $modified_time ? $modified_time : time() );
 
-    $schema = [
-        '@context' => 'https://schema.org',
-        '@type' => 'LiveBlogPosting',
-        'mainEntityOfPage' => get_permalink($post),
-        'headline' => html_entity_decode(get_the_title($post), ENT_QUOTES | ENT_HTML5, 'UTF-8'),
-        'datePublished' => $coverage_start_iso,
-        'dateModified' => $modified_iso,
-        'coverageStartTime' => $coverage_start_iso,
-        'author' => [
-            '@type' => 'Person',
-            'name' => html_entity_decode($author_name, ENT_QUOTES | ENT_HTML5, 'UTF-8'),
-        ],
-        'publisher' => [
-            '@type' => 'Organization',
-            'name' => html_entity_decode(get_bloginfo('name'), ENT_QUOTES | ENT_HTML5, 'UTF-8'),
-            'logo' => [
-                '@type' => 'ImageObject',
-                'url' => $logo_url,
-            ]
-        ],
-        'liveBlogUpdate' => []
-    ];
+	$schema = [
+		'@context'          => 'https://schema.org',
+		'@type'             => 'LiveBlogPosting',
+		'mainEntityOfPage'  => get_permalink( $post ),
+		'headline'          => html_entity_decode( get_the_title( $post ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ),
+		'datePublished'     => $coverage_start_iso,
+		'dateModified'      => $modified_iso,
+		'coverageStartTime' => $coverage_start_iso,
+		'author'            => [
+			'@type' => 'Person',
+			'name'  => html_entity_decode( $author_name, ENT_QUOTES | ENT_HTML5, 'UTF-8' ),
+		],
+		'publisher'         => [
+			'@type' => 'Organization',
+			'name'  => html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ),
+			'logo'  => [
+				'@type' => 'ImageObject',
+				'url'   => $logo_url,
+			],
+		],
+		'liveBlogUpdate'    => [],
+	];
 
-    foreach ($ids as $id) {
-        $updates = zw_liveblog_fetch_updates($id);
-        foreach ($updates as $update) {
-            $text = trim(wp_strip_all_tags($update['contents'] ?? ''));
-            if ($text === '') {
-                continue;
-            }
+	foreach ( $ids as $id ) {
+		$updates = zw_liveblog_fetch_updates( $id );
+		foreach ( $updates as $update ) {
+			$text = trim( wp_strip_all_tags( $update['contents'] ?? '' ) );
+			if ( '' === $text ) {
+				continue;
+			}
 
-            $created_timestamp = $update['created'] ?? 0;
-            $date_published = zw_liveblog_format_wp_datetime($created_timestamp);
-            if ($date_published === '') {
-                continue;
-            }
+			$created_timestamp = $update['created'] ?? 0;
+			$date_published    = zw_liveblog_format_wp_datetime( $created_timestamp );
+			if ( '' === $date_published ) {
+				continue;
+			}
 
-            $update_item = [
-                '@type' => 'BlogPosting',
-                'articleBody' => $text,
-                'datePublished' => $date_published,
-                'url' => get_permalink($post) . '#liveblog-' . esc_attr($update['nid']),
-            ];
+			$update_item = [
+				'@type'         => 'BlogPosting',
+				'articleBody'   => $text,
+				'datePublished' => $date_published,
+				'url'           => get_permalink( $post ) . '#liveblog-' . esc_attr( $update['nid'] ),
+			];
 
-            $headline = trim($update['newstitle'] ?? '');
-            if ($headline !== '') {
-                $update_item['headline'] = $headline;
-            }
+			$headline = trim( $update['newstitle'] ?? '' );
+			if ( '' !== $headline ) {
+				$update_item['headline'] = $headline;
+			}
 
-            $schema['liveBlogUpdate'][] = $update_item;
-        }
+			$schema['liveBlogUpdate'][] = $update_item;
+		}
 
-        // Include coverageEndTime if event is closed.
-        $meta = zw_liveblog_fetch_event_meta($id);
-        if ($meta !== null && !empty($meta['closed']) && isset($meta['last_updated'])) {
-            $coverage_end = zw_liveblog_format_wp_datetime($meta['last_updated']);
-            if ($coverage_end !== '') {
-                $schema['coverageEndTime'] = $coverage_end;
-            }
-        }
-    }
+		// Include coverageEndTime if event is closed.
+		$meta = zw_liveblog_fetch_event_meta( $id );
+		if ( null !== $meta && ! empty( $meta['closed'] ) && isset( $meta['last_updated'] ) ) {
+			$coverage_end = zw_liveblog_format_wp_datetime( $meta['last_updated'] );
+			if ( '' !== $coverage_end ) {
+				$schema['coverageEndTime'] = $coverage_end;
+			}
+		}
+	}
 
-    echo '<script type="application/ld+json">' .
-        wp_json_encode($schema, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) .
-        '</script>';
+	echo '<script type="application/ld+json">' .
+		wp_json_encode( $schema, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ) .
+		'</script>';
 }
-add_action('wp_head', zw_liveblog_add_schema_to_head(...));
+add_action( 'wp_head', zw_liveblog_add_schema_to_head( ... ) );


### PR DESCRIPTION
## Summary
- replace the legacy PHPCS ruleset with the shared oszuidwest WordPress baseline
- format the plugin code for WordPress-Extra and WordPress-Docs
- include uninstall.php in the linted files

## Verification
- vendor/bin/phpcs --standard=phpcs.xml.dist -s
- vendor/bin/phpstan analyse --no-progress --memory-limit=512M
- php -l zw-liveblog.php
- php -l uninstall.php

Closes #10