### PR TITLE
refactor: restructure plugin and align tooling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,13 +5,19 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    groups:
-      all-dependencies:
-        patterns:
-          - "*"
+      time: "07:00"
+      timezone: "Europe/Amsterdam"
+    open-pull-requests-limit: 10
+    labels: ["dependencies", "composer"]
+    rebase-strategy: "auto"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"
+      time: "07:10"
+      timezone: "Europe/Amsterdam"
+    open-pull-requests-limit: 10
+    labels: ["dependencies", "github-actions"]
+    rebase-strategy: "auto"

--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -1,0 +1,29 @@
+---
+name: JS Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.js'
+      - '**/*.ts'
+      - '**/*.css'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'biome.json'
+  pull_request:
+    paths:
+      - '**/*.js'
+      - '**/*.ts'
+      - '**/*.css'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'biome.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    uses: oszuidwest/.github-templates/.github/workflows/wp-js-ci.yml@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,6 @@ on:
       - 'phpcs.xml'
       - 'phpcs.xml.dist'
       - 'phpstan.neon'
-      - 'phpstan-bootstrap.php'
       - 'languages/**'
   pull_request:
     paths:
@@ -21,7 +20,6 @@ on:
       - 'phpcs.xml'
       - 'phpcs.xml.dist'
       - 'phpstan.neon'
-      - 'phpstan-bootstrap.php'
       - 'languages/**'
   workflow_dispatch:
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-composer.lock
-/vendor
 .DS_Store
+/vendor
+/node_modules
+*.mo

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,338 @@
-MIT License
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
 
-Copyright (c) 2025 Streekomroep ZuidWest
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/README.md
+++ b/README.md
@@ -37,8 +37,18 @@ A lightweight WordPress plugin that embeds 24LiveBlog posts using a simple short
 composer install
 vendor/bin/phpcs           # Code style (PSR-12 + WordPress)
 vendor/bin/phpstan analyse # Static analysis
+
+npm install
+npm run lint               # JS/CSS linting with Biome
+npm run lint:fix           # Auto-fix JS/CSS issues
 ```
+
+## Structure
+
+- `zw-liveblog.php` - plugin bootstrap and metadata
+- `includes/` - PHP components for shortcodes, assets, schema, API calls, and card badges
+- `assets/` - front-end CSS and JavaScript loaded by the plugin
 
 ## License
 
-MIT
+GPL-2.0-or-later

--- a/assets/card-badges.css
+++ b/assets/card-badges.css
@@ -1,0 +1,7 @@
+.zw-liveblog-card-badge {
+    align-items: center;
+    background: #dc2626;
+    display: inline-flex;
+    margin-left: 0.35rem;
+    vertical-align: middle;
+}

--- a/assets/card-badges.js
+++ b/assets/card-badges.js
@@ -1,0 +1,76 @@
+(() => {
+    const settings = window.zwLiveblogCardBadges || {};
+    const articles = Array.from(
+        document.querySelectorAll(
+            'article[data-post-id], article[id^="post-"]',
+        ),
+    );
+
+    if (articles.length === 0) {
+        return;
+    }
+
+    const liveIds = new Set(
+        Array.isArray(settings.ids)
+            ? settings.ids.map((id) => Number.parseInt(id, 10)).filter(Boolean)
+            : [],
+    );
+
+    if (liveIds.size === 0) {
+        return;
+    }
+
+    const postIdFor = (article) => {
+        const postId = Number.parseInt(
+            article.getAttribute('data-post-id') ||
+                (article.id || '').replace(/^post-/, ''),
+            10,
+        );
+
+        return Number.isFinite(postId) && postId > 0 ? postId : 0;
+    };
+
+    const findRegionRow = (article) => {
+        const region = Array.from(
+            article.querySelectorAll('a.bg-groen, span.bg-groen'),
+        ).find((element) => {
+            const label = (element.textContent || '').trim();
+            return (
+                label !== '' &&
+                label.length <= 40 &&
+                element.classList.contains('rounded-md')
+            );
+        });
+        const row = region ? region.parentElement : null;
+
+        if (!(row instanceof HTMLElement)) {
+            return null;
+        }
+
+        row.style.alignItems = 'center';
+        row.style.flexWrap = 'wrap';
+        return row;
+    };
+
+    articles.forEach((article) => {
+        if (
+            !liveIds.has(postIdFor(article)) ||
+            article.querySelector('.zw-liveblog-card-badge')
+        ) {
+            return;
+        }
+
+        const row = findRegionRow(article);
+        if (!row) {
+            return;
+        }
+
+        const badge = document.createElement('span');
+        badge.className =
+            'zw-liveblog-card-badge rounded-md px-2 py-0.5 text-xs tracking-wide uppercase font-black font-round text-white';
+        badge.textContent = settings.label || 'LIVE';
+        badge.setAttribute('aria-label', 'Liveblog');
+
+        row.appendChild(badge);
+    });
+})();

--- a/assets/card-badges.js
+++ b/assets/card-badges.js
@@ -20,6 +20,7 @@
         return;
     }
 
+    // Selectors/classes below mirror the current ZuidWest card markup.
     const postIdFor = (article) => {
         const postId = Number.parseInt(
             article.getAttribute('data-post-id') ||
@@ -47,8 +48,6 @@
             return null;
         }
 
-        row.style.alignItems = 'center';
-        row.style.flexWrap = 'wrap';
         return row;
     };
 
@@ -64,6 +63,9 @@
         if (!row) {
             return;
         }
+
+        row.style.alignItems = 'center';
+        row.style.flexWrap = 'wrap';
 
         const badge = document.createElement('span');
         badge.className =

--- a/assets/liveblog-enhancements.js
+++ b/assets/liveblog-enhancements.js
@@ -1,0 +1,123 @@
+(() => {
+    const settings = window.zwLiveblogEnhancements || {};
+    const inputtingLabel = settings.inputtingLabel || 'Aan het typen...';
+    const recentlyUpdatedLabel =
+        settings.recentlyUpdatedLabel || 'Net bijgewerkt';
+    const inputtingSelector = '.lb24-base-editor-inputting';
+    const statusSelector = '.lb24-base-topbar-status';
+    const updatingTextSelector = '.lb24-component-updating1';
+    const statusTextSelector = '.lb24-base-topbar-status-text';
+    const whiteLabelSelector = '.lb24-liveblog-white-label';
+
+    const removeWhiteLabels = (root) => {
+        root.querySelectorAll(whiteLabelSelector).forEach((label) => {
+            label.remove();
+        });
+    };
+
+    const hasVisibleInputtingElement = (root) => {
+        const inputting = root.querySelector(inputtingSelector);
+
+        if (!inputting) {
+            return false;
+        }
+
+        return (
+            !inputting.hidden &&
+            inputting.getAttribute('aria-hidden') !== 'true' &&
+            inputting.style.display !== 'none'
+        );
+    };
+
+    const applyInputtingState = (root) => {
+        const status = root.querySelector(statusSelector);
+        const updatingText = status
+            ? status.querySelector(updatingTextSelector)
+            : null;
+        const statusText =
+            updatingText ||
+            (status ? status.querySelector(statusTextSelector) : null);
+        const wasInputting = root.classList.contains(
+            'zw-liveblog-editor-inputting',
+        );
+        const isInputting = hasVisibleInputtingElement(root);
+
+        root.classList.toggle('zw-liveblog-editor-inputting', isInputting);
+
+        if (!statusText) {
+            return;
+        }
+
+        if (isInputting) {
+            if (
+                !statusText.dataset.zwLiveblogOriginalText &&
+                statusText.textContent !== inputtingLabel
+            ) {
+                statusText.dataset.zwLiveblogOriginalText =
+                    statusText.textContent || '';
+            }
+
+            statusText.textContent = inputtingLabel;
+            return;
+        }
+
+        if (wasInputting && statusText.dataset.zwLiveblogOriginalText) {
+            statusText.textContent = statusText.dataset.zwLiveblogOriginalText;
+            delete statusText.dataset.zwLiveblogOriginalText;
+        }
+
+        if (
+            updatingText &&
+            updatingText.textContent.trim() !== recentlyUpdatedLabel
+        ) {
+            updatingText.textContent = recentlyUpdatedLabel;
+        }
+    };
+
+    const enhanceRoot = (root) => {
+        if (!root || root.dataset.zwLiveblogInputtingEnhanced === '1') {
+            return false;
+        }
+
+        root.dataset.zwLiveblogInputtingEnhanced = '1';
+
+        let animationFrame = 0;
+        const scheduleUpdate = () => {
+            if (animationFrame) {
+                return;
+            }
+
+            animationFrame = window.requestAnimationFrame(() => {
+                animationFrame = 0;
+                removeWhiteLabels(root);
+                applyInputtingState(root);
+            });
+        };
+
+        const observer = new MutationObserver(scheduleUpdate);
+        observer.observe(root, {
+            attributes: true,
+            attributeFilter: ['aria-hidden', 'hidden', 'style'],
+            childList: true,
+            subtree: true,
+        });
+
+        scheduleUpdate();
+        return true;
+    };
+
+    if (enhanceRoot(document.getElementById('LB24'))) {
+        return;
+    }
+
+    const pageObserver = new MutationObserver(() => {
+        if (enhanceRoot(document.getElementById('LB24'))) {
+            pageObserver.disconnect();
+        }
+    });
+
+    pageObserver.observe(document.documentElement, {
+        childList: true,
+        subtree: true,
+    });
+})();

--- a/assets/liveblog-enhancements.js
+++ b/assets/liveblog-enhancements.js
@@ -3,11 +3,11 @@
     const inputtingLabel = settings.inputtingLabel || 'Aan het typen...';
     const recentlyUpdatedLabel =
         settings.recentlyUpdatedLabel || 'Net bijgewerkt';
+    // 24LiveBlog owns these class names; update selectors if their embed markup changes.
     const inputtingSelector = '.lb24-base-editor-inputting';
     const statusSelector = '.lb24-base-topbar-status';
     const updatingTextSelector = '.lb24-component-updating1';
     const statusTextSelector = '.lb24-base-topbar-status-text';
-    const whiteLabelSelector = '.lb24-liveblog-white-label';
     const commentThemeStyleId = 'zw-liveblog-comment-dark-theme';
     const commentThemeCss = `
 html,
@@ -69,12 +69,6 @@ body,
 
     const isDarkTheme = () =>
         document.documentElement.classList.contains('dark');
-
-    const removeWhiteLabels = (root) => {
-        root.querySelectorAll(whiteLabelSelector).forEach((label) => {
-            label.remove();
-        });
-    };
 
     const hasVisibleInputtingElement = (root) => {
         const inputting = root.querySelector(inputtingSelector);
@@ -172,18 +166,70 @@ body,
         frameDocument.head.appendChild(newStyle);
     };
 
+    const watchCommentFrame = (frame) => {
+        const frameDocument = getFrameDocument(frame);
+        if (!frameDocument?.documentElement) {
+            return;
+        }
+
+        updateCommentFrameTheme(frame);
+
+        // The comment app renders .frame-content after load, and a parent-side
+        // observer cannot see inside the iframe. Observe the iframe's own
+        // document so the theme reapplies without polling. A fresh load swaps
+        // the document, so re-observe per document via a marker on <html>.
+        const frameRoot = frameDocument.documentElement;
+        if (frameRoot.dataset.zwLiveblogCommentThemeObserved === '1') {
+            return;
+        }
+        frameRoot.dataset.zwLiveblogCommentThemeObserved = '1';
+
+        let animationFrame = 0;
+        const observer = new MutationObserver(() => {
+            if (animationFrame) {
+                return;
+            }
+
+            animationFrame = window.requestAnimationFrame(() => {
+                animationFrame = 0;
+                updateCommentFrameTheme(frame);
+            });
+        });
+        observer.observe(frameRoot, { childList: true, subtree: true });
+    };
+
     const applyCommentFrameTheme = (root) => {
         root.querySelectorAll('iframe').forEach((frame) => {
             if (frame.dataset.zwLiveblogCommentThemeWatched !== '1') {
                 frame.dataset.zwLiveblogCommentThemeWatched = '1';
                 frame.addEventListener('load', () =>
                     window.requestAnimationFrame(() =>
-                        updateCommentFrameTheme(frame),
+                        watchCommentFrame(frame),
                     ),
                 );
             }
 
-            updateCommentFrameTheme(frame);
+            watchCommentFrame(frame);
+        });
+    };
+
+    const observeThemeChanges = (root) => {
+        let animationFrame = 0;
+        const scheduleThemeUpdate = () => {
+            if (animationFrame) {
+                return;
+            }
+
+            animationFrame = window.requestAnimationFrame(() => {
+                animationFrame = 0;
+                applyCommentFrameTheme(root);
+            });
+        };
+
+        const observer = new MutationObserver(scheduleThemeUpdate);
+        observer.observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ['class'],
         });
     };
 
@@ -192,18 +238,11 @@ body,
             return false;
         }
 
-        if (root.dataset.zwLiveblogInputtingEnhanced === '1') {
-            if (root.dataset.zwLiveblogCommentThemeEnhanced !== '1') {
-                root.dataset.zwLiveblogCommentThemeEnhanced = '1';
-                window.setInterval(() => applyCommentFrameTheme(root), 1000);
-            }
-
-            applyCommentFrameTheme(root);
+        if (root.dataset.zwLiveblogEnhanced === '1') {
             return true;
         }
 
-        root.dataset.zwLiveblogInputtingEnhanced = '1';
-        root.dataset.zwLiveblogCommentThemeEnhanced = '1';
+        root.dataset.zwLiveblogEnhanced = '1';
 
         let animationFrame = 0;
         const scheduleUpdate = () => {
@@ -213,7 +252,6 @@ body,
 
             animationFrame = window.requestAnimationFrame(() => {
                 animationFrame = 0;
-                removeWhiteLabels(root);
                 applyInputtingState(root);
                 applyCommentFrameTheme(root);
             });
@@ -227,7 +265,7 @@ body,
             subtree: true,
         });
 
-        window.setInterval(() => applyCommentFrameTheme(root), 1000);
+        observeThemeChanges(root);
         scheduleUpdate();
         return true;
     };

--- a/assets/liveblog-enhancements.js
+++ b/assets/liveblog-enhancements.js
@@ -8,6 +8,67 @@
     const updatingTextSelector = '.lb24-component-updating1';
     const statusTextSelector = '.lb24-base-topbar-status-text';
     const whiteLabelSelector = '.lb24-liveblog-white-label';
+    const commentThemeStyleId = 'zw-liveblog-comment-dark-theme';
+    const commentThemeCss = `
+html,
+body,
+.frame-content {
+    background: transparent !important;
+    color: #d1d5db !important;
+}
+
+.frame-content [class*="textarea"],
+.frame-content textarea {
+    background: #111827 !important;
+    border-color: #374151 !important;
+    color: #f3f4f6 !important;
+}
+
+.frame-content [class*="textarea"] {
+    border-radius: 4px !important;
+}
+
+.frame-content textarea::placeholder {
+    color: #9ca3af !important;
+    opacity: 1 !important;
+}
+
+.frame-content button,
+.frame-content svg,
+.frame-content svg * {
+    color: #d1d5db !important;
+    fill: #d1d5db !important;
+}
+
+.lb24-livechat-comment,
+.lb24-livechat-comment-box,
+.lb24-livechat-comment-header,
+.lb24-livechat-comment-content,
+.lb24-livechat-comment-footer {
+    color: #d1d5db !important;
+}
+
+.lb24-livechat-comment-username {
+    color: #f3f4f6 !important;
+}
+
+.lb24-livechat-comment-date,
+.lb24-livechat-comment-date * {
+    color: #93c5fd !important;
+}
+
+.lb24-livechat-comment-content-text {
+    color: #d1d5db !important;
+}
+
+.lb24-livechat-comment-footer,
+.lb24-livechat-comment-footer * {
+    color: #9ca3af !important;
+}
+`;
+
+    const isDarkTheme = () =>
+        document.documentElement.classList.contains('dark');
 
     const removeWhiteLabels = (root) => {
         root.querySelectorAll(whiteLabelSelector).forEach((label) => {
@@ -74,12 +135,75 @@
         }
     };
 
+    const getFrameDocument = (frame) => {
+        try {
+            return frame.contentDocument;
+        } catch {
+            return null;
+        }
+    };
+
+    const updateCommentFrameTheme = (frame) => {
+        const frameDocument = getFrameDocument(frame);
+
+        if (!frameDocument?.head) {
+            return;
+        }
+
+        const style = frameDocument.getElementById(commentThemeStyleId);
+
+        if (!isDarkTheme()) {
+            style?.remove();
+            return;
+        }
+
+        if (!frameDocument.querySelector('.frame-content')) {
+            return;
+        }
+
+        if (style) {
+            style.textContent = commentThemeCss;
+            return;
+        }
+
+        const newStyle = frameDocument.createElement('style');
+        newStyle.id = commentThemeStyleId;
+        newStyle.textContent = commentThemeCss;
+        frameDocument.head.appendChild(newStyle);
+    };
+
+    const applyCommentFrameTheme = (root) => {
+        root.querySelectorAll('iframe').forEach((frame) => {
+            if (frame.dataset.zwLiveblogCommentThemeWatched !== '1') {
+                frame.dataset.zwLiveblogCommentThemeWatched = '1';
+                frame.addEventListener('load', () =>
+                    window.requestAnimationFrame(() =>
+                        updateCommentFrameTheme(frame),
+                    ),
+                );
+            }
+
+            updateCommentFrameTheme(frame);
+        });
+    };
+
     const enhanceRoot = (root) => {
-        if (!root || root.dataset.zwLiveblogInputtingEnhanced === '1') {
+        if (!root) {
             return false;
         }
 
+        if (root.dataset.zwLiveblogInputtingEnhanced === '1') {
+            if (root.dataset.zwLiveblogCommentThemeEnhanced !== '1') {
+                root.dataset.zwLiveblogCommentThemeEnhanced = '1';
+                window.setInterval(() => applyCommentFrameTheme(root), 1000);
+            }
+
+            applyCommentFrameTheme(root);
+            return true;
+        }
+
         root.dataset.zwLiveblogInputtingEnhanced = '1';
+        root.dataset.zwLiveblogCommentThemeEnhanced = '1';
 
         let animationFrame = 0;
         const scheduleUpdate = () => {
@@ -91,6 +215,7 @@
                 animationFrame = 0;
                 removeWhiteLabels(root);
                 applyInputtingState(root);
+                applyCommentFrameTheme(root);
             });
         };
 
@@ -102,6 +227,7 @@
             subtree: true,
         });
 
+        window.setInterval(() => applyCommentFrameTheme(root), 1000);
         scheduleUpdate();
         return true;
     };

--- a/assets/liveblog.css
+++ b/assets/liveblog.css
@@ -1,0 +1,83 @@
+.lb24-news-list-item.lb24-base-list-ad {
+    display: none !important;
+}
+
+#LB24 .lb24-base-editor-inputting,
+#LB24 .lb24-liveblog-white-label {
+    display: none !important;
+}
+
+#LB24.zw-liveblog-editor-inputting .lb24-base-topbar-status {
+    white-space: nowrap;
+}
+
+.dark #LB24,
+.dark #LB24 .lb24-liveblog-container,
+.dark #LB24 .lb24-base-container,
+.dark #LB24 .lb24-base-main-content,
+.dark #LB24 .lb24-base-list,
+.dark #LB24 .lb24-base-list-news {
+    background: transparent !important;
+    color: #d1d5db !important;
+}
+
+.dark #LB24 .lb24-base-topbar-container,
+.dark #LB24 .lb24-base-topbar-status,
+.dark #LB24 .lb24-base-topbar-sort,
+.dark #LB24 .lb24-base-topbar-volume {
+    background: #e5e7eb !important;
+    border-color: #d1d5db !important;
+    color: #111827 !important;
+}
+
+.dark #LB24 .lb24-base-topbar-container *,
+.dark #LB24 .lb24-base-topbar-status *,
+.dark #LB24 .lb24-base-topbar-sort *,
+.dark #LB24 .lb24-base-topbar-volume * {
+    color: #111827 !important;
+    fill: #111827 !important;
+}
+
+.dark #LB24 .lb24-base-news-container,
+.dark #LB24 .lb24-theme-dark .lb24-base-news-container {
+    background: #1f2937 !important;
+    border-color: #374151 !important;
+    color: #d1d5db !important;
+}
+
+.dark #LB24 .lb24-base-news-container:hover {
+    background: #374151 !important;
+}
+
+.dark #LB24 .lb24-base-news-head,
+.dark #LB24 .lb24-list-item-highlight {
+    background: #1f2937 !important;
+    border-color: #374151 !important;
+}
+
+.dark #LB24 .lb24-base-news-title,
+.dark #LB24 .lb24-base-news-title-text {
+    color: #ffffff !important;
+}
+
+.dark #LB24 .lb24-base-news-content,
+.dark #LB24 .lb24-base-news-content p,
+.dark #LB24 .lb24-component-content {
+    color: #d1d5db !important;
+}
+
+.dark #LB24 .lb24-base-news-date {
+    background: #374151 !important;
+    border-color: #374151 !important;
+    color: #ffffff !important;
+}
+
+.dark #LB24 .lb24-list-item-line,
+.dark #LB24 .lb24-base-news-update {
+    border-color: #374151 !important;
+}
+
+.dark #LB24 .lb24-component-operation,
+.dark #LB24 .lb24-component-operation * {
+    color: #9ca3af !important;
+}

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "complexity": {
+        "noImportantStyles": "off"
+      }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 4
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always"
+    }
+  },
+  "css": {
+    "formatter": {
+      "indentStyle": "space",
+      "indentWidth": 4
+    }
+  },
+  "files": {
+    "includes": [
+      "**/assets/**/*.js",
+      "**/assets/**/*.css",
+      "!**/vendor/**",
+      "!**/node_modules/**"
+    ]
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,19 @@
 {
   "name": "oszuidwest/zw-liveblog",
+  "description": "WordPress plugin for embedding 24LiveBlog posts with live badges and LiveBlogPosting schema",
   "type": "wordpress-plugin",
+  "license": "GPL-2.0-or-later",
+  "keywords": ["wordpress", "plugin", "liveblog", "24liveblog", "schema"],
+  "authors": [
+    {
+      "name": "Streekomroep ZuidWest",
+      "homepage": "https://www.zuidwesttv.nl"
+    }
+  ],
+  "support": {
+    "issues": "https://github.com/oszuidwest/zw-liveblog/issues",
+    "source": "https://github.com/oszuidwest/zw-liveblog"
+  },
   "require": {
     "php": "^8.3"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,877 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "29b37ed01220d7d9968dfb27954b04db",
+    "packages": [],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.2",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.2",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2026-05-06T08:26:05+00:00"
+        },
+        {
+            "name": "php-stubs/wordpress-stubs",
+            "version": "v6.9.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/wordpress-stubs.git",
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/90a9412826b9944f93b10bf41d795b5fe68abcd5",
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5",
+                "shasum": ""
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "5.6.1"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "nikic/php-parser": "^5.5",
+                "php": "^7.4 || ^8.0",
+                "php-stubs/generator": "^0.8.6",
+                "phpdocumentor/reflection-docblock": "^6.0",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^9.5",
+                "symfony/polyfill-php80": "*",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
+                "symfony/polyfill-php80": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+                "szepeviktor/phpstan-wordpress": "WordPress extensions for PHPStan"
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress function and class declaration stubs for static analysis.",
+            "homepage": "https://github.com/php-stubs/wordpress-stubs",
+            "keywords": [
+                "PHPStan",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.4"
+            },
+            "time": "2026-05-01T20:36:01+00:00"
+        },
+        {
+            "name": "phpcompatibility/php-compatibility",
+            "version": "9.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibility.git",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibility/zipball/9fb324479acf6f39452e0655d2429cc0d3914243",
+                "reference": "9fb324479acf6f39452e0655d2429cc0d3914243",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.3 || ^3.0.2"
+            },
+            "conflict": {
+                "squizlabs/php_codesniffer": "2.6.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "homepage": "https://github.com/wimg",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCompatibility/PHPCompatibility/graphs/contributors"
+                }
+            ],
+            "description": "A set of sniffs for PHP_CodeSniffer that checks for PHP cross-version compatibility.",
+            "homepage": "http://techblog.wimgodden.be/tag/codesniffer/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
+            "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-paragonie",
+            "version": "1.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
+                "reference": "244d7b04fc4bc2117c15f5abe23eb933b5f02bbf",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "paragonie/random_compat": "dev-master",
+                "paragonie/sodium_compat": "dev-master"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by the Paragonie polyfill libraries.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "paragonie",
+                "phpcs",
+                "polyfill",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-09-19T17:43:28+00:00"
+        },
+        {
+            "name": "phpcompatibility/phpcompatibility-wp",
+            "version": "2.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
+                "reference": "7c8d18b4d90dac9e86b0869a608fa09158e168fa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/7c8d18b4d90dac9e86b0869a608fa09158e168fa",
+                "reference": "7c8d18b4d90dac9e86b0869a608fa09158e168fa",
+                "shasum": ""
+            },
+            "require": {
+                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/phpcompatibility-paragonie": "^1.0",
+                "squizlabs/php_codesniffer": "^3.3"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0"
+            },
+            "suggest": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Wim Godden",
+                    "role": "lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "lead"
+                }
+            ],
+            "description": "A ruleset for PHP_CodeSniffer to check for PHP cross-version compatibility issues in projects, while accounting for polyfills provided by WordPress.",
+            "homepage": "http://phpcompatibility.com/",
+            "keywords": [
+                "compatibility",
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "security": "https://github.com/PHPCompatibility/PHPCompatibilityWP/security/policy",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCompatibility",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcompatibility",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-10-18T00:05:59+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "b598aa890815b8df16363271b659d73280129101"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/b598aa890815b8df16363271b659d73280129101",
+                "reference": "b598aa890815b8df16363271b659d73280129101",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.2.0",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-12T23:06:57+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "reference": "c216317e96c8b3f5932808f9b0f1f7a14e3bbf55",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.13.5 || ^4.0.1"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcsstandards/phpcsdevcs": "^1.2.0",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0 || ^3.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "phpcs4",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-12-08T14:27:58+00:00"
+        },
+        {
+            "name": "phpstan/extension-installer",
+            "version": "1.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/85e90b3942d06b2326fba0403ec24fe912372936",
+                "reference": "85e90b3942d06b2326fba0403ec24fe912372936",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.9.0 || ^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12 || ^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.4.3"
+            },
+            "time": "2024-09-04T20:21:43+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.2.2",
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
+                "reference": "e5cc34d491a90e79c216d824f60fe21fd4d93bd6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-05T09:00:01+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.13.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "reference": "0ca86845ce43291e8f5692c7356fccf3bcf02bf4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-11-04T16:30:35+00:00"
+        },
+        {
+            "name": "szepeviktor/phpstan-wordpress",
+            "version": "v2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
+                "reference": "aa722f037b2d034828cd6c55ebe9e5c74961927e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/aa722f037b2d034828cd6c55ebe9e5c74961927e",
+                "reference": "aa722f037b2d034828cd6c55ebe9e5c74961927e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0",
+                "php-stubs/wordpress-stubs": "^6.6.2",
+                "phpstan/phpstan": "^2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.1.14",
+                "composer/semver": "^3.4",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.1",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.0",
+                "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.0",
+                "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
+            },
+            "suggest": {
+                "swissspidy/phpstan-no-private": "Detect usage of internal core functions, classes and methods"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SzepeViktor\\PHPStan\\WordPress\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "WordPress extensions for PHPStan",
+            "keywords": [
+                "PHPStan",
+                "code analyse",
+                "code analysis",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v2.0.3"
+            },
+            "time": "2025-09-14T02:58:22+00:00"
+        },
+        {
+            "name": "wp-coding-standards/wpcs",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
+                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "reference": "7795ec6fa05663d716a549d0b44e47ffc8b0d4a6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
+                "php": ">=7.2",
+                "phpcsstandards/phpcsextra": "^1.5.0",
+                "phpcsstandards/phpcsutils": "^1.1.0",
+                "squizlabs/php_codesniffer": "^3.13.4"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpcompatibility/php-compatibility": "^10.0.0@dev",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
+            },
+            "suggest": {
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
+            },
+            "type": "phpcodesniffer-standard",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/WordPress/WordPress-Coding-Standards/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer rules (sniffs) to enforce WordPress coding conventions",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis",
+                "wordpress"
+            ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "custom"
+                }
+            ],
+            "time": "2025-11-25T12:08:04+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^8.3"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}

--- a/includes/class-zw-liveblog-api.php
+++ b/includes/class-zw-liveblog-api.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * 24LiveBlog API client.
+ *
+ * @package ZuidWestLiveblog
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Fetches and caches event data from 24LiveBlog.
+ */
+final class ZW_Liveblog_Api {
+	private const BASE_URL  = 'https://data.24liveplus.com/v1/retrieve_server/x/event/';
+	private const CACHE_TTL = 60;
+
+	/**
+	 * Fetch the latest 100 updates.
+	 *
+	 * @param string $event_id The 24LiveBlog event ID.
+	 * @return array<int, array<string, mixed>>
+	 */
+	public function fetch_updates( string $event_id ): array {
+		if ( ! $this->is_valid_event_id( $event_id ) ) {
+			return [];
+		}
+
+		$transient_key = 'zw_liveblog_updates_' . md5( $event_id );
+		$cached        = get_transient( $transient_key );
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
+
+		$data = $this->get_json( self::BASE_URL . $event_id . '/news/?inverted_order=1&last_nid=&limit=100' );
+		if ( null === $data ) {
+			return [];
+		}
+
+		$news = is_array( $data['data']['news'] ?? null ) ? $data['data']['news'] : [];
+
+		set_transient( $transient_key, $news, self::CACHE_TTL );
+		return $news;
+	}
+
+	/**
+	 * Fetch metadata, such as closed status and last_updated.
+	 *
+	 * @param string $event_id The 24LiveBlog event ID.
+	 * @return array<string, mixed>|null
+	 */
+	public function fetch_event_meta( string $event_id ): ?array {
+		if ( ! $this->is_valid_event_id( $event_id ) ) {
+			return null;
+		}
+
+		$transient_key = 'zw_liveblog_meta_' . md5( $event_id );
+		$cached        = get_transient( $transient_key );
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
+
+		$data = $this->get_json( self::BASE_URL . $event_id . '/' );
+		$meta = is_array( $data['data']['event'] ?? null ) ? $data['data']['event'] : null;
+
+		if ( null !== $meta ) {
+			set_transient( $transient_key, $meta, self::CACHE_TTL );
+		}
+
+		return $meta;
+	}
+
+	/**
+	 * Request and decode JSON from 24LiveBlog.
+	 *
+	 * @param string $url API URL.
+	 * @return array<string, mixed>|null
+	 */
+	private function get_json( string $url ): ?array {
+		$response = wp_remote_get( $url, [ 'timeout' => 5 ] );
+		if ( is_wp_error( $response ) ) {
+			return null;
+		}
+
+		$body = wp_remote_retrieve_body( $response );
+		if ( '' === $body || ! json_validate( $body ) ) {
+			return null;
+		}
+
+		$data = json_decode( $body, true );
+		return is_array( $data ) ? $data : null;
+	}
+
+	/**
+	 * Validate a 24LiveBlog event ID.
+	 *
+	 * @param string $event_id Event ID.
+	 * @return bool True when the ID is numeric.
+	 */
+	private function is_valid_event_id( string $event_id ): bool {
+		return 1 === preg_match( '/^\d+$/', $event_id );
+	}
+}

--- a/includes/class-zw-liveblog-assets.php
+++ b/includes/class-zw-liveblog-assets.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Front-end asset loading.
+ *
+ * @package ZuidWestLiveblog
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Enqueues 24LiveBlog and plugin front-end assets.
+ */
+final class ZW_Liveblog_Assets {
+	/**
+	 * Register asset hooks.
+	 */
+	public function register_hooks(): void {
+		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue' ] );
+	}
+
+	/**
+	 * Enqueue assets only on singular content containing a liveblog shortcode.
+	 */
+	public function enqueue(): void {
+		$post = get_post();
+		if ( ! is_singular() || ! $post instanceof WP_Post || ! has_shortcode( $post->post_content, 'liveblog' ) ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			'liveblog-24-js',
+			'https://v.24liveblog.com/24.js',
+			[],
+			ZW_LIVEBLOG_VERSION,
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			]
+		);
+
+		wp_enqueue_style(
+			'zw-liveblog-style',
+			plugins_url( 'assets/liveblog.css', ZW_LIVEBLOG_FILE ),
+			[],
+			ZW_LIVEBLOG_VERSION
+		);
+
+		wp_enqueue_script(
+			'zw-liveblog-enhancements',
+			plugins_url( 'assets/liveblog-enhancements.js', ZW_LIVEBLOG_FILE ),
+			[ 'liveblog-24-js' ],
+			ZW_LIVEBLOG_VERSION,
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			]
+		);
+
+		$settings_json = wp_json_encode(
+			[
+				'inputtingLabel'       => __( 'Aan het typen...', 'zw-liveblog' ),
+				'recentlyUpdatedLabel' => __( 'Net bijgewerkt', 'zw-liveblog' ),
+			]
+		);
+
+		if ( false !== $settings_json ) {
+			wp_add_inline_script( 'zw-liveblog-enhancements', 'window.zwLiveblogEnhancements = ' . $settings_json . ';', 'before' );
+		}
+	}
+}

--- a/includes/class-zw-liveblog-assets.php
+++ b/includes/class-zw-liveblog-assets.php
@@ -14,6 +14,22 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 final class ZW_Liveblog_Assets {
 	/**
+	 * Content helper.
+	 *
+	 * @var ZW_Liveblog_Content
+	 */
+	private ZW_Liveblog_Content $content;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ZW_Liveblog_Content $content Content helper.
+	 */
+	public function __construct( ZW_Liveblog_Content $content ) {
+		$this->content = $content;
+	}
+
+	/**
 	 * Register asset hooks.
 	 */
 	public function register_hooks(): void {
@@ -21,11 +37,11 @@ final class ZW_Liveblog_Assets {
 	}
 
 	/**
-	 * Enqueue assets only on singular content containing a liveblog shortcode.
+	 * Enqueue assets only on singular content containing a valid liveblog shortcode.
 	 */
 	public function enqueue(): void {
 		$post = get_post();
-		if ( ! is_singular() || ! $post instanceof WP_Post || ! has_shortcode( $post->post_content, 'liveblog' ) ) {
+		if ( ! is_singular() || ! $post instanceof WP_Post || ! $this->content->post_has_liveblog( $post ) ) {
 			return;
 		}
 

--- a/includes/class-zw-liveblog-card-badges.php
+++ b/includes/class-zw-liveblog-card-badges.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Live badges for theme cards and tiles.
+ *
+ * @package ZuidWestLiveblog
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Adds LIVE badges to posts that contain a liveblog shortcode.
+ */
+final class ZW_Liveblog_Card_Badges {
+	/**
+	 * Content helper.
+	 *
+	 * @var ZW_Liveblog_Content
+	 */
+	private ZW_Liveblog_Content $content;
+
+	/**
+	 * Collected frontend post IDs.
+	 *
+	 * @var array<int, true>
+	 */
+	private array $live_post_ids = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ZW_Liveblog_Content $content Content helper.
+	 */
+	public function __construct( ZW_Liveblog_Content $content ) {
+		$this->content = $content;
+	}
+
+	/**
+	 * Register hooks.
+	 */
+	public function register_hooks(): void {
+		add_filter( 'the_posts', [ $this, 'collect_liveblog_posts' ] );
+		add_action( 'wp_footer', [ $this, 'print_footer_assets' ], 5 );
+	}
+
+	/**
+	 * Collect liveblog post IDs from frontend queries.
+	 *
+	 * @param array<int, WP_Post> $posts Query posts.
+	 * @return array<int, WP_Post> Unchanged query posts.
+	 */
+	public function collect_liveblog_posts( array $posts ): array {
+		if ( ! $this->should_run_on_frontend() ) {
+			return $posts;
+		}
+
+		foreach ( $posts as $post ) {
+			if ( 'publish' === $post->post_status && $this->content->post_has_liveblog( $post ) ) {
+				$this->live_post_ids[ $post->ID ] = true;
+			}
+		}
+
+		return $posts;
+	}
+
+	/**
+	 * Print badge assets when collected IDs exist.
+	 */
+	public function print_footer_assets(): void {
+		if ( ! $this->should_run_on_frontend() || [] === $this->live_post_ids ) {
+			return;
+		}
+
+		$live_post_ids = array_values( array_filter( array_map( 'absint', array_keys( $this->live_post_ids ) ) ) );
+		if ( [] === $live_post_ids ) {
+			return;
+		}
+
+		$settings_json = wp_json_encode(
+			[
+				'ids'   => $live_post_ids,
+				'label' => __( 'LIVE', 'zw-liveblog' ),
+			]
+		);
+
+		if ( false === $settings_json ) {
+			return;
+		}
+
+		wp_enqueue_style(
+			'zw-liveblog-card-badges',
+			plugins_url( 'assets/card-badges.css', ZW_LIVEBLOG_FILE ),
+			[],
+			ZW_LIVEBLOG_VERSION
+		);
+		wp_print_styles( [ 'zw-liveblog-card-badges' ] );
+
+		wp_enqueue_script(
+			'zw-liveblog-card-badges',
+			plugins_url( 'assets/card-badges.js', ZW_LIVEBLOG_FILE ),
+			[],
+			ZW_LIVEBLOG_VERSION,
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			]
+		);
+		wp_add_inline_script( 'zw-liveblog-card-badges', 'window.zwLiveblogCardBadges = ' . $settings_json . ';', 'before' );
+	}
+
+	/**
+	 * Whether card badge behavior should run in the current request.
+	 */
+	private function should_run_on_frontend(): bool {
+		return ! is_admin() && ! is_feed() && ! wp_is_json_request();
+	}
+}

--- a/includes/class-zw-liveblog-content.php
+++ b/includes/class-zw-liveblog-content.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Post content helpers.
+ *
+ * @package ZuidWestLiveblog
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Parses posts for liveblog shortcodes.
+ */
+final class ZW_Liveblog_Content {
+	/**
+	 * Cached post liveblog presence.
+	 *
+	 * @var array<int, bool>
+	 */
+	private array $post_has_liveblog_cache = [];
+
+	/**
+	 * Extract all liveblog IDs from content.
+	 *
+	 * @param string $content Post content.
+	 * @return array<int, string>
+	 */
+	public function extract_liveblog_ids( string $content ): array {
+		if ( '' === $content || ! has_shortcode( $content, 'liveblog' ) ) {
+			return [];
+		}
+
+		$ids = [];
+		preg_match_all( '/' . get_shortcode_regex( [ 'liveblog' ] ) . '/', $content, $matches, PREG_SET_ORDER );
+		foreach ( $matches as $shortcode ) {
+			if ( ! isset( $shortcode[2], $shortcode[3], $shortcode[6] ) || 'liveblog' !== $shortcode[2] ) {
+				continue;
+			}
+
+			if ( '[' === $shortcode[1] && ']' === $shortcode[6] ) {
+				continue;
+			}
+
+			$atts = shortcode_parse_atts( $shortcode[3] );
+			if ( empty( $atts['id'] ) ) {
+				continue;
+			}
+
+			$id = sanitize_text_field( (string) $atts['id'] );
+			if ( preg_match( '/^\d+$/', $id ) ) {
+				$ids[] = $id;
+			}
+		}
+
+		return array_values( array_unique( $ids ) );
+	}
+
+	/**
+	 * Check whether a post contains at least one valid liveblog shortcode.
+	 *
+	 * @param WP_Post|int|null $post Post object or ID.
+	 * @return bool True when the post contains a valid liveblog shortcode.
+	 */
+	public function post_has_liveblog( WP_Post|int|null $post ): bool {
+		$post = get_post( $post );
+		if ( ! $post instanceof WP_Post ) {
+			return false;
+		}
+
+		if ( array_key_exists( $post->ID, $this->post_has_liveblog_cache ) ) {
+			return $this->post_has_liveblog_cache[ $post->ID ];
+		}
+
+		$this->post_has_liveblog_cache[ $post->ID ] = [] !== $this->extract_liveblog_ids( $post->post_content );
+		return $this->post_has_liveblog_cache[ $post->ID ];
+	}
+}

--- a/includes/class-zw-liveblog-lifecycle.php
+++ b/includes/class-zw-liveblog-lifecycle.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Plugin lifecycle handlers.
+ *
+ * @package ZuidWestLiveblog
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles cached transient cleanup.
+ */
+final class ZW_Liveblog_Lifecycle {
+	/**
+	 * Delete cached 24LiveBlog transients.
+	 */
+	public static function delete_transients(): void {
+		global $wpdb;
+
+		$wpdb->query(
+			$wpdb->prepare(
+				'DELETE FROM ' . $wpdb->options . ' WHERE option_name LIKE %s OR option_name LIKE %s',
+				'_transient_zw_liveblog_%',
+				'_transient_timeout_zw_liveblog_%'
+			)
+		);
+	}
+}

--- a/includes/class-zw-liveblog-plugin.php
+++ b/includes/class-zw-liveblog-plugin.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Plugin composition root.
+ *
+ * @package ZuidWestLiveblog
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Wires plugin services and hooks together.
+ */
+final class ZW_Liveblog_Plugin {
+	/**
+	 * Content helper.
+	 *
+	 * @var ZW_Liveblog_Content
+	 */
+	private ZW_Liveblog_Content $content;
+
+	/**
+	 * API client.
+	 *
+	 * @var ZW_Liveblog_Api
+	 */
+	private ZW_Liveblog_Api $api;
+
+	/**
+	 * Shortcode component.
+	 *
+	 * @var ZW_Liveblog_Shortcode
+	 */
+	private ZW_Liveblog_Shortcode $shortcode;
+
+	/**
+	 * Asset component.
+	 *
+	 * @var ZW_Liveblog_Assets
+	 */
+	private ZW_Liveblog_Assets $assets;
+
+	/**
+	 * Card badge component.
+	 *
+	 * @var ZW_Liveblog_Card_Badges
+	 */
+	private ZW_Liveblog_Card_Badges $card_badges;
+
+	/**
+	 * Schema component.
+	 *
+	 * @var ZW_Liveblog_Schema
+	 */
+	private ZW_Liveblog_Schema $schema;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->content     = new ZW_Liveblog_Content();
+		$this->api         = new ZW_Liveblog_Api();
+		$this->shortcode   = new ZW_Liveblog_Shortcode();
+		$this->assets      = new ZW_Liveblog_Assets();
+		$this->card_badges = new ZW_Liveblog_Card_Badges( $this->content );
+		$this->schema      = new ZW_Liveblog_Schema( $this->content, $this->api );
+	}
+
+	/**
+	 * Register component hooks.
+	 */
+	public function register_hooks(): void {
+		$this->shortcode->register_hooks();
+		$this->assets->register_hooks();
+		$this->card_badges->register_hooks();
+		$this->schema->register_hooks();
+	}
+}

--- a/includes/class-zw-liveblog-plugin.php
+++ b/includes/class-zw-liveblog-plugin.php
@@ -62,7 +62,7 @@ final class ZW_Liveblog_Plugin {
 		$this->content     = new ZW_Liveblog_Content();
 		$this->api         = new ZW_Liveblog_Api();
 		$this->shortcode   = new ZW_Liveblog_Shortcode();
-		$this->assets      = new ZW_Liveblog_Assets();
+		$this->assets      = new ZW_Liveblog_Assets( $this->content );
 		$this->card_badges = new ZW_Liveblog_Card_Badges( $this->content );
 		$this->schema      = new ZW_Liveblog_Schema( $this->content, $this->api );
 	}

--- a/includes/class-zw-liveblog-schema.php
+++ b/includes/class-zw-liveblog-schema.php
@@ -1,0 +1,229 @@
+<?php
+/**
+ * LiveBlogPosting JSON-LD schema.
+ *
+ * @package ZuidWestLiveblog
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Outputs LiveBlogPosting schema for singular liveblog posts.
+ */
+final class ZW_Liveblog_Schema {
+	/**
+	 * Content helper.
+	 *
+	 * @var ZW_Liveblog_Content
+	 */
+	private ZW_Liveblog_Content $content;
+
+	/**
+	 * API client.
+	 *
+	 * @var ZW_Liveblog_Api
+	 */
+	private ZW_Liveblog_Api $api;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ZW_Liveblog_Content $content Content helper.
+	 * @param ZW_Liveblog_Api     $api API client.
+	 */
+	public function __construct( ZW_Liveblog_Content $content, ZW_Liveblog_Api $api ) {
+		$this->content = $content;
+		$this->api     = $api;
+	}
+
+	/**
+	 * Register hooks.
+	 */
+	public function register_hooks(): void {
+		add_action( 'wp_head', [ $this, 'add_to_head' ] );
+	}
+
+	/**
+	 * Output LiveBlogPosting schema with up to 100 updates per liveblog.
+	 */
+	public function add_to_head(): void {
+		if ( ! is_singular() ) {
+			return;
+		}
+
+		$post = get_post();
+		if ( ! $post instanceof WP_Post ) {
+			return;
+		}
+
+		$ids = $this->content->extract_liveblog_ids( $post->post_content );
+		if ( [] === $ids ) {
+			return;
+		}
+
+		$schema = $this->build_schema( $post, $ids );
+		$json   = wp_json_encode( $schema, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES );
+		if ( false === $json ) {
+			return;
+		}
+
+		wp_print_inline_script_tag( $json, [ 'type' => 'application/ld+json' ] );
+	}
+
+	/**
+	 * Build the JSON-LD schema array.
+	 *
+	 * @param WP_Post           $post Post object.
+	 * @param array<int,string> $ids Liveblog event IDs.
+	 * @return array<string, mixed>
+	 */
+	private function build_schema( WP_Post $post, array $ids ): array {
+		$author_name        = get_the_author_meta( 'display_name', (int) $post->post_author );
+		$logo_id            = get_theme_mod( 'custom_logo' );
+		$logo_url           = $logo_id ? wp_get_attachment_image_url( $logo_id, 'full' ) : '';
+		$coverage_start_iso = $this->format_wp_datetime( $this->get_coverage_start( $post, $ids ) );
+		$modified_time      = get_post_modified_time( 'U', true, $post );
+		$modified_iso       = $this->format_wp_datetime( $modified_time ? $modified_time : time() );
+
+		$schema = [
+			'@context'          => 'https://schema.org',
+			'@type'             => 'LiveBlogPosting',
+			'mainEntityOfPage'  => get_permalink( $post ),
+			'headline'          => html_entity_decode( get_the_title( $post ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ),
+			'datePublished'     => $coverage_start_iso,
+			'dateModified'      => $modified_iso,
+			'coverageStartTime' => $coverage_start_iso,
+			'author'            => [
+				'@type' => 'Person',
+				'name'  => html_entity_decode( $author_name, ENT_QUOTES | ENT_HTML5, 'UTF-8' ),
+			],
+			'publisher'         => [
+				'@type' => 'Organization',
+				'name'  => html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ),
+				'logo'  => [
+					'@type' => 'ImageObject',
+					'url'   => $logo_url ? $logo_url : '',
+				],
+			],
+			'liveBlogUpdate'    => [],
+		];
+
+		foreach ( $ids as $id ) {
+			$this->append_updates( $schema, $post, $id );
+			$this->append_coverage_end( $schema, $id );
+		}
+
+		return $schema;
+	}
+
+	/**
+	 * Resolve coverage start time.
+	 *
+	 * @param WP_Post           $post Post object.
+	 * @param array<int,string> $ids Liveblog event IDs.
+	 * @return int Unix timestamp.
+	 */
+	private function get_coverage_start( WP_Post $post, array $ids ): int {
+		$coverage_start = get_post_time( 'U', true, $post );
+		if ( false !== $coverage_start && '' !== $coverage_start ) {
+			return (int) $coverage_start;
+		}
+
+		foreach ( $ids as $id ) {
+			$meta = $this->api->fetch_event_meta( $id );
+			if ( null !== $meta && isset( $meta['start_time'] ) && is_numeric( $meta['start_time'] ) && 0 < (int) $meta['start_time'] ) {
+				return (int) $meta['start_time'];
+			}
+		}
+
+		return time();
+	}
+
+	/**
+	 * Append liveblog updates to the schema.
+	 *
+	 * @param array<string, mixed> $schema   Schema array, passed by reference.
+	 * @param WP_Post              $post     Post object.
+	 * @param string               $event_id Liveblog event ID.
+	 */
+	private function append_updates( array &$schema, WP_Post $post, string $event_id ): void {
+		foreach ( $this->api->fetch_updates( $event_id ) as $update ) {
+			$update_item = $this->build_update_item( $post, $update );
+			if ( null !== $update_item ) {
+				$schema['liveBlogUpdate'][] = $update_item;
+			}
+		}
+	}
+
+	/**
+	 * Build a single BlogPosting update item.
+	 *
+	 * @param WP_Post              $post Post object.
+	 * @param array<string, mixed> $update 24LiveBlog update data.
+	 * @return array<string, mixed>|null
+	 */
+	private function build_update_item( WP_Post $post, array $update ): ?array {
+		$text = trim( wp_strip_all_tags( (string) ( $update['contents'] ?? '' ) ) );
+		if ( '' === $text ) {
+			return null;
+		}
+
+		$date_published = $this->format_wp_datetime( $update['created'] ?? 0 );
+		if ( '' === $date_published ) {
+			return null;
+		}
+
+		$update_item = [
+			'@type'         => 'BlogPosting',
+			'articleBody'   => $text,
+			'datePublished' => $date_published,
+			'url'           => get_permalink( $post ) . '#liveblog-' . rawurlencode( (string) ( $update['nid'] ?? '' ) ),
+		];
+
+		$headline = trim( wp_strip_all_tags( (string) ( $update['newstitle'] ?? '' ) ) );
+		if ( '' !== $headline ) {
+			$update_item['headline'] = $headline;
+		}
+
+		return $update_item;
+	}
+
+	/**
+	 * Append coverageEndTime when the event is closed.
+	 *
+	 * @param array<string, mixed> $schema   Schema array, passed by reference.
+	 * @param string               $event_id Liveblog event ID.
+	 */
+	private function append_coverage_end( array &$schema, string $event_id ): void {
+		$meta = $this->api->fetch_event_meta( $event_id );
+		if ( null === $meta || empty( $meta['closed'] ) || ! isset( $meta['last_updated'] ) ) {
+			return;
+		}
+
+		$coverage_end = $this->format_wp_datetime( $meta['last_updated'] );
+		if ( '' !== $coverage_end ) {
+			$schema['coverageEndTime'] = $coverage_end;
+		}
+	}
+
+	/**
+	 * Convert timestamp to local timezone in ISO 8601.
+	 *
+	 * @param mixed $timestamp Unix timestamp.
+	 * @return string Formatted timestamp, or empty string when unavailable.
+	 */
+	private function format_wp_datetime( mixed $timestamp ): string {
+		if ( empty( $timestamp ) || ! is_numeric( $timestamp ) || $timestamp <= 0 ) {
+			return '';
+		}
+
+		try {
+			$dt = ( new DateTimeImmutable( '@' . $timestamp ) )->setTimezone( wp_timezone() );
+			return $dt->format( DATE_W3C );
+		} catch ( Exception ) {
+			return '';
+		}
+	}
+}

--- a/includes/class-zw-liveblog-shortcode.php
+++ b/includes/class-zw-liveblog-shortcode.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Shortcode registration and rendering.
+ *
+ * @package ZuidWestLiveblog
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles the [liveblog] shortcode.
+ */
+final class ZW_Liveblog_Shortcode {
+	/**
+	 * Register shortcode hooks.
+	 */
+	public function register_hooks(): void {
+		add_shortcode( 'liveblog', [ $this, 'render' ] );
+	}
+
+	/**
+	 * Render shortcode output.
+	 *
+	 * @param array<string, string|int>|string $atts Shortcode attributes.
+	 * @return string Shortcode output.
+	 */
+	public function render( array|string $atts ): string {
+		$atts        = shortcode_atts( [ 'id' => '' ], is_array( $atts ) ? $atts : [], 'liveblog' );
+		$liveblog_id = sanitize_text_field( (string) $atts['id'] );
+
+		if ( '' === $liveblog_id ) {
+			return '';
+		}
+
+		return '<div id="LB24_LIVE_CONTENT" data-eid="' . esc_attr( $liveblog_id ) . '"></div>';
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,188 @@
+{
+  "name": "zw-liveblog",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "zw-liveblog",
+      "devDependencies": {
+        "@biomejs/biome": "^2.3.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.5.1.tgz",
+      "integrity": "sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.5.1",
+        "@biomejs/cli-darwin-x64": "2.5.1",
+        "@biomejs/cli-linux-arm64": "2.5.1",
+        "@biomejs/cli-linux-arm64-musl": "2.5.1",
+        "@biomejs/cli-linux-x64": "2.5.1",
+        "@biomejs/cli-linux-x64-musl": "2.5.1",
+        "@biomejs/cli-win32-arm64": "2.5.1",
+        "@biomejs/cli-win32-x64": "2.5.1"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.5.1.tgz",
+      "integrity": "sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.5.1.tgz",
+      "integrity": "sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.5.1.tgz",
+      "integrity": "sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.5.1.tgz",
+      "integrity": "sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.5.1.tgz",
+      "integrity": "sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.5.1.tgz",
+      "integrity": "sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.5.1.tgz",
+      "integrity": "sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.5.1.tgz",
+      "integrity": "sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "zw-liveblog",
+  "private": true,
+  "description": "WordPress plugin front-end tooling for ZuidWest Liveblog",
+  "scripts": {
+    "lint": "biome check assets/",
+    "lint:fix": "biome check --write assets/",
+    "format": "biome format --write assets/"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.3.0"
+  }
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,43 +1,44 @@
 <?xml version="1.0"?>
-<ruleset name="oszuidwest WordPress plugin baseline">
-    <description>
-        Baseline coding standards for oszuidwest WordPress plugins.
-        Consumer phpcs.xml adds &lt;file/&gt;, &lt;config name="text_domain"/&gt;,
-        and a PrefixAllGlobals rule with the plugin's prefixes.
-    </description>
+<ruleset name="zw-liveblog">
+    <description>WordPress Coding Standards for ZuidWest Liveblog.</description>
 
-    <!-- Scan only PHP files. Consumer overrides /file/ entries. -->
+    <!-- Files to scan -->
+    <file>zw-liveblog.php</file>
+    <file>includes</file>
+    <file>uninstall.php</file>
+
+    <!-- Tooling -->
     <arg name="extensions" value="php"/>
     <arg name="colors"/>
     <arg value="sp"/>
 
-    <file>zw-liveblog.php</file>
-    <file>uninstall.php</file>
-
-    <!-- Stop PHP 8 from emitting deprecation warnings inside phpcs itself. -->
     <ini name="error_reporting" value="E_ALL &amp; ~E_DEPRECATED"/>
 
-    <!-- Versions enforced across all oszuidwest plugins. -->
+    <!-- Versions -->
     <config name="testVersion" value="8.3-8.4"/>
     <config name="minimum_wp_version" value="6.8"/>
-    <config name="text_domain" value="zw-liveblog"/>
 
-    <!--
-        WordPress-Extra is WordPress-Core plus best-practice sniffs.
-        WordPress-Docs adds docblock requirements.
-        PHPCompatibilityWP enforces the testVersion above.
-    -->
+    <!-- Per-plugin -->
+    <config name="text_domain" value="zw-liveblog"/>
+    <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+        <properties>
+            <property name="prefixes" type="array">
+                <element value="zw_liveblog_"/>
+                <element value="ZW_Liveblog_"/>
+                <element value="ZW_LIVEBLOG_"/>
+            </property>
+        </properties>
+    </rule>
+
+    <!-- Standards -->
     <rule ref="WordPress-Extra">
-        <!-- We use short array syntax. -->
         <exclude name="Universal.Arrays.DisallowShortArraySyntax"/>
     </rule>
     <rule ref="WordPress-Docs">
-        <!-- PHPStan type aliases aren't real PHP types. -->
         <exclude name="Squiz.Commenting.FunctionComment.IncorrectTypeHint"/>
     </rule>
     <rule ref="PHPCompatibilityWP"/>
 
-    <!-- Generous line limit; warning only. -->
     <rule ref="Generic.Files.LineLength">
         <properties>
             <property name="lineLimit" value="160"/>
@@ -45,16 +46,6 @@
         </properties>
     </rule>
 
-    <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
-        <properties>
-            <property name="prefixes" type="array">
-                <element value="zw_liveblog_"/>
-                <element value="ZW_LIVEBLOG_"/>
-            </property>
-        </properties>
-    </rule>
-
-    <!-- Excluded from every consumer. -->
     <exclude-pattern>vendor/*</exclude-pattern>
     <exclude-pattern>node_modules/*</exclude-pattern>
 </ruleset>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,3 +3,8 @@ parameters:
   phpVersion: 80300
   paths:
     - zw-liveblog.php
+    - includes
+  excludePaths:
+    - vendor
+  parallel:
+    maximumNumberOfProcesses: 1

--- a/uninstall.php
+++ b/uninstall.php
@@ -11,11 +11,6 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit;
 }
 
-global $wpdb;
-$wpdb->query(
-	$wpdb->prepare(
-		'DELETE FROM ' . $wpdb->options . ' WHERE option_name LIKE %s OR option_name LIKE %s',
-		'_transient_zw_liveblog_%',
-		'_transient_timeout_zw_liveblog_%'
-	)
-);
+require_once __DIR__ . '/includes/class-zw-liveblog-lifecycle.php';
+
+ZW_Liveblog_Lifecycle::delete_transients();

--- a/zw-liveblog.php
+++ b/zw-liveblog.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: ZuidWest Liveblog
  * Description: Replaces the [liveblog id="123456"] shortcode with the 24LiveBlog embed code, hides advertisements, and adds LiveBlogPosting schema.
- * Version: 1.7.1
+ * Version: 1.7.10
  * Author: Streekomroep ZuidWest
  * Author URI: https://www.zuidwesttv.nl
  * License: GPL-2.0-or-later
@@ -18,266 +18,24 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+define( 'ZW_LIVEBLOG_FILE', __FILE__ );
+define( 'ZW_LIVEBLOG_DIR', plugin_dir_path( __FILE__ ) );
 define( 'ZW_LIVEBLOG_VERSION', get_file_data( __FILE__, [ 'Version' => 'Version' ] )['Version'] );
 
-register_activation_hook(
-	__FILE__,
-	function (): void {
-		// Placeholder for future activation tasks.
+require_once ZW_LIVEBLOG_DIR . 'includes/class-zw-liveblog-lifecycle.php';
+require_once ZW_LIVEBLOG_DIR . 'includes/class-zw-liveblog-content.php';
+require_once ZW_LIVEBLOG_DIR . 'includes/class-zw-liveblog-api.php';
+require_once ZW_LIVEBLOG_DIR . 'includes/class-zw-liveblog-shortcode.php';
+require_once ZW_LIVEBLOG_DIR . 'includes/class-zw-liveblog-assets.php';
+require_once ZW_LIVEBLOG_DIR . 'includes/class-zw-liveblog-card-badges.php';
+require_once ZW_LIVEBLOG_DIR . 'includes/class-zw-liveblog-schema.php';
+require_once ZW_LIVEBLOG_DIR . 'includes/class-zw-liveblog-plugin.php';
+
+register_deactivation_hook( __FILE__, [ ZW_Liveblog_Lifecycle::class, 'delete_transients' ] );
+
+add_action(
+	'plugins_loaded',
+	static function (): void {
+		( new ZW_Liveblog_Plugin() )->register_hooks();
 	}
 );
-
-register_deactivation_hook(
-	__FILE__,
-	function (): void {
-		global $wpdb;
-		$wpdb->query(
-			$wpdb->prepare(
-				'DELETE FROM ' . $wpdb->options . ' WHERE option_name LIKE %s OR option_name LIKE %s',
-				'_transient_zw_liveblog_%',
-				'_transient_timeout_zw_liveblog_%'
-			)
-		);
-	}
-);
-
-/**
- * Shortcode handler.
- *
- * @param array<string, string|int>|string $atts Shortcode attributes.
- * @return string Shortcode output.
- */
-function zw_liveblog_shortcode( array|string $atts ): string {
-	$atts        = shortcode_atts( [ 'id' => '' ], $atts, 'liveblog' );
-	$liveblog_id = sanitize_text_field( $atts['id'] );
-	if ( '' === $liveblog_id ) {
-		return '';
-	}
-	return '<div id="LB24_LIVE_CONTENT" data-eid="' . esc_attr( $liveblog_id ) . '"></div>';
-}
-add_shortcode( 'liveblog', zw_liveblog_shortcode( ... ) );
-
-/**
- * Enqueue 24LiveBlog assets only when shortcode is used.
- */
-function zw_liveblog_enqueue_assets(): void {
-	$post = get_post();
-	if ( is_singular() && $post && has_shortcode( $post->post_content, 'liveblog' ) ) {
-		wp_enqueue_script(
-			'liveblog-24-js',
-			'https://v.24liveblog.com/24.js',
-			[],
-			ZW_LIVEBLOG_VERSION,
-			[
-				'in_footer' => true,
-				'strategy'  => 'defer',
-			]
-		);
-		wp_register_style( 'zw-liveblog-style', false, [], ZW_LIVEBLOG_VERSION );
-		wp_enqueue_style( 'zw-liveblog-style' );
-		$css = '
-            .lb24-news-list-item.lb24-base-list-ad { display: none !important; }
-            #LB24 .lb24-theme-dark .lb24-base-news-container:hover {
-                background: #0000002b !important;
-            }
-        ';
-		wp_add_inline_style( 'zw-liveblog-style', $css );
-	}
-}
-add_action( 'wp_enqueue_scripts', zw_liveblog_enqueue_assets( ... ) );
-
-/**
- * Fetch the latest 100 updates (cached for 60s).
- *
- * @param string $event_id The 24LiveBlog event ID.
- * @return array<int, array<string, mixed>>
- */
-function zw_liveblog_fetch_updates( string $event_id ): array {
-	$transient_key = 'zw_liveblog_updates_' . md5( $event_id );
-	$cached        = get_transient( $transient_key );
-	if ( is_array( $cached ) ) {
-		return $cached;
-	}
-
-	$url      = 'https://data.24liveplus.com/v1/retrieve_server/x/event/' . $event_id . '/news/?inverted_order=1&last_nid=&limit=100';
-	$response = wp_remote_get( $url, [ 'timeout' => 5 ] );
-	if ( is_wp_error( $response ) ) {
-		return [];
-	}
-
-	$body = wp_remote_retrieve_body( $response );
-	if ( ! json_validate( $body ) ) {
-		return [];
-	}
-	$data = json_decode( $body, true );
-	$news = $data['data']['news'] ?? [];
-
-	set_transient( $transient_key, $news, 60 );
-	return $news;
-}
-
-/**
- * Fetch metadata (e.g., closed status, last_updated).
- *
- * @param string $event_id The 24LiveBlog event ID.
- * @return array<string, mixed>|null
- */
-function zw_liveblog_fetch_event_meta( string $event_id ): ?array {
-	$transient_key = 'zw_liveblog_meta_' . md5( $event_id );
-	$cached        = get_transient( $transient_key );
-	if ( is_array( $cached ) ) {
-		return $cached;
-	}
-
-	$url      = 'https://data.24liveplus.com/v1/retrieve_server/x/event/' . $event_id . '/';
-	$response = wp_remote_get( $url, [ 'timeout' => 5 ] );
-	if ( is_wp_error( $response ) ) {
-		return null;
-	}
-
-	$body = wp_remote_retrieve_body( $response );
-	if ( ! json_validate( $body ) ) {
-		return null;
-	}
-	$data = json_decode( $body, true );
-	$meta = $data['data']['event'] ?? null;
-
-	set_transient( $transient_key, $meta, 60 );
-	return $meta;
-}
-
-/**
- * Convert timestamp to local timezone in ISO 8601.
- *
- * @param mixed $timestamp Unix timestamp.
- * @return string Formatted timestamp, or empty string when unavailable.
- */
-function zw_liveblog_format_wp_datetime( mixed $timestamp ): string {
-	if ( empty( $timestamp ) || ! is_numeric( $timestamp ) || $timestamp <= 0 ) {
-		return '';
-	}
-	try {
-		$dt = ( new DateTimeImmutable( '@' . $timestamp ) )
-			->setTimezone( wp_timezone() );
-		return $dt->format( DATE_W3C );
-	} catch ( Exception $e ) {
-		return '';
-	}
-}
-
-/**
- * Extract all liveblog IDs from content.
- *
- * @param string $content Post content.
- * @return array<int, string>
- */
-function zw_liveblog_extract_liveblog_ids( string $content ): array {
-	preg_match_all( '/\[liveblog\s+id=["\']?(\d+)["\']?\]/i', $content, $matches );
-	return array_unique( $matches[1] );
-}
-
-/**
- * Outputs LiveBlogPosting schema with up to 100 updates per liveblog.
- */
-function zw_liveblog_add_schema_to_head(): void {
-	if ( ! is_singular() ) {
-		return;
-	}
-
-	$post = get_post();
-	if ( ! $post ) {
-		return;
-	}
-	$ids = zw_liveblog_extract_liveblog_ids( $post->post_content );
-	if ( [] === $ids ) {
-		return;
-	}
-
-	$author_name = get_the_author_meta( 'display_name', (int) $post->post_author );
-	$logo_id     = get_theme_mod( 'custom_logo' );
-	$logo_url    = $logo_id ? wp_get_attachment_image_url( $logo_id, 'full' ) : '';
-	// Get coverage start time - use post time if published, otherwise current time.
-	$coverage_start = get_post_time( 'U', true, $post );
-	if ( false === $coverage_start || '' === $coverage_start ) {
-		// For drafts/previews, try to get start_time from first liveblog event.
-		// Otherwise use current time.
-		$coverage_start = time();
-		foreach ( $ids as $id ) {
-			$meta = zw_liveblog_fetch_event_meta( $id );
-			if ( null !== $meta && isset( $meta['start_time'] ) && 0 < $meta['start_time'] ) {
-				$coverage_start = $meta['start_time'];
-				break;
-			}
-		}
-	}
-	$coverage_start_iso = zw_liveblog_format_wp_datetime( $coverage_start );
-	$modified_time      = get_post_modified_time( 'U', true, $post );
-	$modified_iso       = zw_liveblog_format_wp_datetime( $modified_time ? $modified_time : time() );
-
-	$schema = [
-		'@context'          => 'https://schema.org',
-		'@type'             => 'LiveBlogPosting',
-		'mainEntityOfPage'  => get_permalink( $post ),
-		'headline'          => html_entity_decode( get_the_title( $post ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ),
-		'datePublished'     => $coverage_start_iso,
-		'dateModified'      => $modified_iso,
-		'coverageStartTime' => $coverage_start_iso,
-		'author'            => [
-			'@type' => 'Person',
-			'name'  => html_entity_decode( $author_name, ENT_QUOTES | ENT_HTML5, 'UTF-8' ),
-		],
-		'publisher'         => [
-			'@type' => 'Organization',
-			'name'  => html_entity_decode( get_bloginfo( 'name' ), ENT_QUOTES | ENT_HTML5, 'UTF-8' ),
-			'logo'  => [
-				'@type' => 'ImageObject',
-				'url'   => $logo_url,
-			],
-		],
-		'liveBlogUpdate'    => [],
-	];
-
-	foreach ( $ids as $id ) {
-		$updates = zw_liveblog_fetch_updates( $id );
-		foreach ( $updates as $update ) {
-			$text = trim( wp_strip_all_tags( $update['contents'] ?? '' ) );
-			if ( '' === $text ) {
-				continue;
-			}
-
-			$created_timestamp = $update['created'] ?? 0;
-			$date_published    = zw_liveblog_format_wp_datetime( $created_timestamp );
-			if ( '' === $date_published ) {
-				continue;
-			}
-
-			$update_item = [
-				'@type'         => 'BlogPosting',
-				'articleBody'   => $text,
-				'datePublished' => $date_published,
-				'url'           => get_permalink( $post ) . '#liveblog-' . esc_attr( $update['nid'] ),
-			];
-
-			$headline = trim( $update['newstitle'] ?? '' );
-			if ( '' !== $headline ) {
-				$update_item['headline'] = $headline;
-			}
-
-			$schema['liveBlogUpdate'][] = $update_item;
-		}
-
-		// Include coverageEndTime if event is closed.
-		$meta = zw_liveblog_fetch_event_meta( $id );
-		if ( null !== $meta && ! empty( $meta['closed'] ) && isset( $meta['last_updated'] ) ) {
-			$coverage_end = zw_liveblog_format_wp_datetime( $meta['last_updated'] );
-			if ( '' !== $coverage_end ) {
-				$schema['coverageEndTime'] = $coverage_end;
-			}
-		}
-	}
-
-	echo '<script type="application/ld+json">' .
-		wp_json_encode( $schema, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES ) .
-		'</script>';
-}
-add_action( 'wp_head', zw_liveblog_add_schema_to_head( ... ) );

--- a/zw-liveblog.php
+++ b/zw-liveblog.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: ZuidWest Liveblog
  * Description: Replaces the [liveblog id="123456"] shortcode with the 24LiveBlog embed code, hides advertisements, and adds LiveBlogPosting schema.
- * Version: 1.7.10
+ * Version: 1.7.11
  * Author: Streekomroep ZuidWest
  * Author URI: https://www.zuidwesttv.nl
  * License: GPL-2.0-or-later

--- a/zw-liveblog.php
+++ b/zw-liveblog.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: ZuidWest Liveblog
  * Description: Replaces the [liveblog id="123456"] shortcode with the 24LiveBlog embed code, hides advertisements, and adds LiveBlogPosting schema.
- * Version: 1.7.11
+ * Version: 1.8.0
  * Author: Streekomroep ZuidWest
  * Author URI: https://www.zuidwesttv.nl
  * License: GPL-2.0-or-later


### PR DESCRIPTION
## Summary
- Split the plugin bootstrap into focused includes for lifecycle, shortcode, assets, card badges, API, content parsing, and schema.
- Move front-end CSS and JS into assets and keep the liveblog enhancements behavior intact.
- Align tooling with zw-knabbel-wp: Composer metadata, PHPCS/PHPStan config, PHPStan bootstrap, Biome, JS lint workflow, Dependabot, and lockfiles.

## Checks
- composer validate --strict
- npm run lint
- composer exec -- phpcs
- composer exec -- phpstan analyse --memory-limit=512M
- php -l on all PHP files
- node --check on asset JS files
- git diff --check