### PR TITLE
fix: hide LIVE badge for closed liveblogs + cut comment-observer CPU

### DIFF
--- a/assets/liveblog-enhancements.js
+++ b/assets/liveblog-enhancements.js
@@ -156,7 +156,7 @@ body,
         }
 
         if (style) {
-            style.textContent = commentThemeCss;
+            // Already injected; nothing touches our <head> style, so no rewrite.
             return;
         }
 
@@ -174,15 +174,23 @@ body,
 
         updateCommentFrameTheme(frame);
 
-        // The comment app renders .frame-content after load, and a parent-side
-        // observer cannot see inside the iframe. Observe the iframe's own
-        // document so the theme reapplies without polling. A fresh load swaps
-        // the document, so re-observe per document via a marker on <html>.
         const frameRoot = frameDocument.documentElement;
         if (frameRoot.dataset.zwLiveblogCommentThemeObserved === '1') {
             return;
         }
         frameRoot.dataset.zwLiveblogCommentThemeObserved = '1';
+
+        // The comment app renders .frame-content shortly after load, and a
+        // parent-side observer cannot see inside the iframe. If it is already
+        // there, the one-time injection above is all we need. Otherwise watch
+        // the iframe's own document ONLY until it appears, then disconnect: a
+        // live chat mutates 100+/s and the injected <head> style survives that
+        // churn, so a permanent observer would burn CPU for nothing. Theme
+        // toggles are handled by observeThemeChanges; a fresh load swaps the
+        // document and re-arms this via the iframe load listener.
+        if (frameDocument.querySelector('.frame-content')) {
+            return;
+        }
 
         let animationFrame = 0;
         const observer = new MutationObserver(() => {
@@ -193,6 +201,9 @@ body,
             animationFrame = window.requestAnimationFrame(() => {
                 animationFrame = 0;
                 updateCommentFrameTheme(frame);
+                if (frameDocument.querySelector('.frame-content')) {
+                    observer.disconnect();
+                }
             });
         });
         observer.observe(frameRoot, { childList: true, subtree: true });

--- a/includes/class-zw-liveblog-api.php
+++ b/includes/class-zw-liveblog-api.php
@@ -55,9 +55,8 @@ final class ZW_Liveblog_Api {
 			return null;
 		}
 
-		$transient_key = 'zw_liveblog_meta_' . md5( $event_id );
-		$cached        = get_transient( $transient_key );
-		if ( is_array( $cached ) ) {
+		$cached = $this->fetch_cached_event_meta( $event_id );
+		if ( null !== $cached ) {
 			return $cached;
 		}
 
@@ -65,10 +64,48 @@ final class ZW_Liveblog_Api {
 		$meta = is_array( $data['data']['event'] ?? null ) ? $data['data']['event'] : null;
 
 		if ( null !== $meta ) {
-			set_transient( $transient_key, $meta, self::CACHE_TTL );
+			set_transient( $this->event_meta_transient_key( $event_id ), $meta, self::CACHE_TTL );
 		}
 
 		return $meta;
+	}
+
+	/**
+	 * Fetch cached metadata without making a remote request.
+	 *
+	 * @param string $event_id The 24LiveBlog event ID.
+	 * @return array<string, mixed>|null
+	 */
+	public function fetch_cached_event_meta( string $event_id ): ?array {
+		if ( ! $this->is_valid_event_id( $event_id ) ) {
+			return null;
+		}
+
+		$cached = get_transient( $this->event_meta_transient_key( $event_id ) );
+		return is_array( $cached ) ? $cached : null;
+	}
+
+	/**
+	 * Whether event metadata should be treated as open.
+	 *
+	 * Missing metadata is considered open so an API outage never hides a
+	 * genuinely live badge.
+	 *
+	 * @param array<string, mixed>|null $meta Event metadata.
+	 * @return bool True when the event is open or its status is unknown.
+	 */
+	public function is_event_meta_open( ?array $meta ): bool {
+		return null === $meta || empty( $meta['closed'] );
+	}
+
+	/**
+	 * Build the metadata transient key for an event.
+	 *
+	 * @param string $event_id The 24LiveBlog event ID.
+	 * @return string Transient key.
+	 */
+	private function event_meta_transient_key( string $event_id ): string {
+		return 'zw_liveblog_meta_' . md5( $event_id );
 	}
 
 	/**

--- a/includes/class-zw-liveblog-card-badges.php
+++ b/includes/class-zw-liveblog-card-badges.php
@@ -21,6 +21,13 @@ final class ZW_Liveblog_Card_Badges {
 	private ZW_Liveblog_Content $content;
 
 	/**
+	 * API client.
+	 *
+	 * @var ZW_Liveblog_Api
+	 */
+	private ZW_Liveblog_Api $api;
+
+	/**
 	 * Collected frontend post IDs.
 	 *
 	 * @var array<int, true>
@@ -28,12 +35,21 @@ final class ZW_Liveblog_Card_Badges {
 	private array $live_post_ids = [];
 
 	/**
+	 * Cached open-liveblog status per post.
+	 *
+	 * @var array<int, bool>
+	 */
+	private array $open_cache = [];
+
+	/**
 	 * Constructor.
 	 *
 	 * @param ZW_Liveblog_Content $content Content helper.
+	 * @param ZW_Liveblog_Api     $api API client.
 	 */
-	public function __construct( ZW_Liveblog_Content $content ) {
+	public function __construct( ZW_Liveblog_Content $content, ZW_Liveblog_Api $api ) {
 		$this->content = $content;
+		$this->api     = $api;
 	}
 
 	/**
@@ -56,12 +72,40 @@ final class ZW_Liveblog_Card_Badges {
 		}
 
 		foreach ( $posts as $post ) {
-			if ( 'publish' === $post->post_status && $this->content->post_has_liveblog( $post ) ) {
+			if ( 'publish' === $post->post_status && $this->has_open_liveblog( $post ) ) {
 				$this->live_post_ids[ $post->ID ] = true;
 			}
 		}
 
 		return $posts;
+	}
+
+	/**
+	 * Whether a post contains at least one liveblog event that is still open.
+	 *
+	 * Mirrors the schema's closed-event detection so a finished liveblog stops
+	 * showing a LIVE badge. Unknown status (API failure) is treated as open so a
+	 * transient outage never hides a genuinely live badge.
+	 *
+	 * @param WP_Post $post Post object.
+	 * @return bool True when the post has an open (non-closed) liveblog event.
+	 */
+	private function has_open_liveblog( WP_Post $post ): bool {
+		if ( array_key_exists( $post->ID, $this->open_cache ) ) {
+			return $this->open_cache[ $post->ID ];
+		}
+
+		$open = false;
+		foreach ( $this->content->extract_liveblog_ids( $post->post_content ) as $id ) {
+			$meta = $this->api->fetch_event_meta( $id );
+			if ( null === $meta || empty( $meta['closed'] ) ) {
+				$open = true;
+				break;
+			}
+		}
+
+		$this->open_cache[ $post->ID ] = $open;
+		return $open;
 	}
 
 	/**

--- a/includes/class-zw-liveblog-card-badges.php
+++ b/includes/class-zw-liveblog-card-badges.php
@@ -56,7 +56,7 @@ final class ZW_Liveblog_Card_Badges {
 	 * Register hooks.
 	 */
 	public function register_hooks(): void {
-		add_filter( 'the_posts', [ $this, 'collect_liveblog_posts' ] );
+		add_filter( 'the_posts', [ $this, 'collect_liveblog_posts' ], 10, 2 );
 		add_action( 'wp_footer', [ $this, 'print_footer_assets' ], 5 );
 	}
 
@@ -64,15 +64,19 @@ final class ZW_Liveblog_Card_Badges {
 	 * Collect liveblog post IDs from frontend queries.
 	 *
 	 * @param array<int, WP_Post> $posts Query posts.
+	 * @param WP_Query|null       $query Query object.
 	 * @return array<int, WP_Post> Unchanged query posts.
 	 */
-	public function collect_liveblog_posts( array $posts ): array {
+	public function collect_liveblog_posts( array $posts, ?WP_Query $query = null ): array {
 		if ( ! $this->should_run_on_frontend() ) {
 			return $posts;
 		}
 
+		// Secondary queries may use warmed transients, but must not start blocking HTTP.
+		$allow_remote_meta = $query instanceof WP_Query && $query->is_main_query();
+
 		foreach ( $posts as $post ) {
-			if ( 'publish' === $post->post_status && $this->has_open_liveblog( $post ) ) {
+			if ( 'publish' === $post->post_status && $this->has_open_liveblog( $post, $allow_remote_meta ) ) {
 				$this->live_post_ids[ $post->ID ] = true;
 			}
 		}
@@ -87,24 +91,28 @@ final class ZW_Liveblog_Card_Badges {
 	 * showing a LIVE badge. Unknown status (API failure) is treated as open so a
 	 * transient outage never hides a genuinely live badge.
 	 *
-	 * @param WP_Post $post Post object.
+	 * @param WP_Post $post              Post object.
+	 * @param bool    $allow_remote_meta Whether uncached event metadata may be fetched remotely.
 	 * @return bool True when the post has an open (non-closed) liveblog event.
 	 */
-	private function has_open_liveblog( WP_Post $post ): bool {
+	private function has_open_liveblog( WP_Post $post, bool $allow_remote_meta ): bool {
 		if ( array_key_exists( $post->ID, $this->open_cache ) ) {
 			return $this->open_cache[ $post->ID ];
 		}
 
 		$open = false;
 		foreach ( $this->content->extract_liveblog_ids( $post->post_content ) as $id ) {
-			$meta = $this->api->fetch_event_meta( $id );
-			if ( null === $meta || empty( $meta['closed'] ) ) {
+			$meta = $allow_remote_meta ? $this->api->fetch_event_meta( $id ) : $this->api->fetch_cached_event_meta( $id );
+			if ( $this->api->is_event_meta_open( $meta ) ) {
 				$open = true;
 				break;
 			}
 		}
 
-		$this->open_cache[ $post->ID ] = $open;
+		if ( $allow_remote_meta ) {
+			$this->open_cache[ $post->ID ] = $open;
+		}
+
 		return $open;
 	}
 

--- a/includes/class-zw-liveblog-plugin.php
+++ b/includes/class-zw-liveblog-plugin.php
@@ -63,7 +63,7 @@ final class ZW_Liveblog_Plugin {
 		$this->api         = new ZW_Liveblog_Api();
 		$this->shortcode   = new ZW_Liveblog_Shortcode();
 		$this->assets      = new ZW_Liveblog_Assets( $this->content );
-		$this->card_badges = new ZW_Liveblog_Card_Badges( $this->content );
+		$this->card_badges = new ZW_Liveblog_Card_Badges( $this->content, $this->api );
 		$this->schema      = new ZW_Liveblog_Schema( $this->content, $this->api );
 	}
 

--- a/includes/class-zw-liveblog-schema.php
+++ b/includes/class-zw-liveblog-schema.php
@@ -198,7 +198,7 @@ final class ZW_Liveblog_Schema {
 	 */
 	private function append_coverage_end( array &$schema, string $event_id ): void {
 		$meta = $this->api->fetch_event_meta( $event_id );
-		if ( null === $meta || empty( $meta['closed'] ) || ! isset( $meta['last_updated'] ) ) {
+		if ( $this->api->is_event_meta_open( $meta ) || ! isset( $meta['last_updated'] ) ) {
 			return;
 		}
 

--- a/zw-liveblog.php
+++ b/zw-liveblog.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: ZuidWest Liveblog
  * Description: Replaces the [liveblog id="123456"] shortcode with the 24LiveBlog embed code, hides advertisements, and adds LiveBlogPosting schema.
- * Version: 1.8.0
+ * Version: 1.8.1
  * Author: Streekomroep ZuidWest
  * Author URI: https://www.zuidwesttv.nl
  * License: GPL-2.0-or-later


### PR DESCRIPTION
Two fixes from verifying the 1.8.0 dark-mode work on production, plus a version bump.

- **fix:** closed liveblogs kept showing a **LIVE** card badge. Badges now check the `closed` signal via `fetch_event_meta()` (shared with the schema) and skip closed events. Fail-open on API errors. Meta is only fetched over HTTP on the main query; secondary queries read warm cache only, so listing pages never block on 24LiveBlog.
- **perf:** the in-iframe comment-theme `MutationObserver` fired ~120/s for the whole page lifetime. It now disconnects once the `<head>` style is injected; theme toggles and fresh iframe loads re-arm it.
- **chore:** bump to 1.8.1 (busts the `?ver=` asset cache).
